### PR TITLE
Translate `react-19-upgrade-guide.md` to pt-br

### DIFF
--- a/src/content/blog/2024/04/25/react-19-upgrade-guide.md
+++ b/src/content/blog/2024/04/25/react-19-upgrade-guide.md
@@ -1,86 +1,83 @@
 ---
-title: "React 19 Beta Upgrade Guide"
+title: "Guia de Atualização para o Beta do React 19"
 author: Ricky Hanlon
 date: 2024/04/25
-description: The improvements added to React 19 require some breaking changes, but we've worked to make the upgrade as smooth as possible and we don't expect the changes to impact most apps. In this post, we will guide you through the steps for upgrading libraries to React 19 beta.
+description: As melhorias adicionadas ao React 19 requerem algumas mudanças disruptivas, mas trabalhamos para tornar a atualização o mais suave possível e não esperamos que as mudanças impactem a maioria dos aplicativos. Neste post, guiaremos você através dos passos para atualizar as bibliotecas para o beta do React 19.
 ---
 
-April 25, 2024 by [Ricky Hanlon](https://twitter.com/rickhanlonii)
+25 de abril de 2024 por [Ricky Hanlon](https://twitter.com/rickhanlonii)
 
 ---
 
 <Note>
 
-This beta release is for libraries to prepare for React 19. App developers should upgrade to 18.3.0 and wait for React 19 stable as we work with libraries and make changes based on feedback.
+Este lançamento beta é para bibliotecas se prepararem para o React 19. Desenvolvedores de aplicativos devem atualizar para 18.3.0 e aguardar o React 19 estável enquanto trabalhamos com bibliotecas e fazemos mudanças com base no feedback.
 
 </Note>
 
-
 <Intro>
 
-The improvements added to React 19 require some breaking changes, but we've worked to make the upgrade as smooth as possible and we don't expect the changes to impact most apps.
+As melhorias adicionadas ao React 19 requerem algumas mudanças disruptivas, mas trabalhamos para tornar a atualização o mais suave possível e não esperamos que as mudanças impactem a maioria dos aplicativos.
 
-To help make the upgrade easier, today we are also publishing React 18.3.
+Para ajudar a tornar a atualização mais fácil, hoje também estamos publicando o React 18.3.
 
 </Intro>
 
 <Note>
 
-#### React 18.3 has also been published {/*react-18-3*/}
+#### O React 18.3 também foi publicado {/*react-18-3*/}
 
-To help make the upgrade to React 19 easier, we've published a `react@18.3` release that is identical to 18.2 but adds warnings for deprecated APIs and other changes that are needed for React 19. 
+Para ajudar a tornar a atualização para o React 19 mais fácil, publicamos uma versão `react@18.3` que é idêntica à 18.2, mas adiciona avisos para APIs obsoletas e outras mudanças necessárias para o React 19.
 
-We recommend upgrading to React 18.3 first to help identify any issues before upgrading to React 19.
+Recomendamos atualizar para o React 18.3 primeiro para ajudar a identificar quaisquer problemas antes de atualizar para o React 19.
 
-For a list of changes in 18.3 see the [Release Notes](https://github.com/facebook/react/blob/main/CHANGELOG.md).
+Para uma lista de mudanças na 18.3, veja as [Notas de Lançamento](https://github.com/facebook/react/blob/main/CHANGELOG.md).
 
 </Note>
 
-In this post, we will guide you through the steps for upgrading libraries to React 19 beta:
+Neste post, guiaremos você através dos passos para atualizar as bibliotecas para o beta do React 19:
 
-- [Installing](#installing)
-- [Breaking changes](#breaking-changes)
-- [New deprecations](#new-deprecations)
-- [Notable changes](#notable-changes)
-- [TypeScript changes](#typescript-changes)
+- [Instalação](#installing)
+- [Mudanças disruptivas](#breaking-changes)
+- [Novas desativações](#new-deprecations)
+- [Mudanças notáveis](#notable-changes)
+- [Mudanças no TypeScript](#typescript-changes)
 - [Changelog](#changelog)
 
-If you'd like to help us test React 19, follow the steps in this upgrade guide and [report any issues](https://github.com/facebook/react/issues/new?assignees=&labels=React+19&projects=&template=19.md&title=%5BReact+19%5D) you encounter. For a list of new features added to React 19 beta, see the [React 19 release post](/blog/2024/04/25/react-19).
+Se você gostaria de nos ajudar a testar o React 19, siga os passos neste guia de atualização e [relate quaisquer problemas](https://github.com/facebook/react/issues/new?assignees=&labels=React+19&projects=&template=19.md&title=%5BReact+19%5D) que você encontrar. Para uma lista de novos recursos adicionados ao beta do React 19, veja o [post de lançamento do React 19](/blog/2024/04/25/react-19).
 
 ---
-## Installing {/*installing*/}
+## Instalação {/*installing*/}
 
 <Note>
 
-#### New JSX Transform is now required {/*new-jsx-transform-is-now-required*/}
+#### Novo JSX Transform agora é obrigatório {/*new-jsx-transform-is-now-required*/}
 
-We introduced a [new JSX transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) in 2020 to improve bundle size and use JSX without importing React. In React 19, we're adding additional improvements like using ref as a prop and JSX speed improvements that require the new transform.
+Introduzimos um [novo JSX transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) em 2020 para melhorar o tamanho do pacote e usar JSX sem importar o React. No React 19, estamos adicionando melhorias adicionais, como usar ref como uma prop e melhorias na velocidade do JSX que requerem o novo transform.
 
-If the new transform is not enabled, you will see this warning:
+Se o novo transform não estiver ativado, você verá este aviso:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-Your app (or one of its dependencies) is using an outdated JSX transform. Update to the modern JSX transform for faster performance: https://react.dev/link/new-jsx-transform
+Seu aplicativo (ou uma de suas dependências) está usando um transform JSX desatualizado. Atualize para o transform JSX moderno para melhor desempenho: https://react.dev/link/new-jsx-transform
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
-
-We expect most apps will not be affected since the transform is enabled in most environments already. For manual instructions on how to upgrade, please see the [announcement post](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html).
+Esperamos que a maioria dos aplicativos não seja afetada, uma vez que o transform esteja ativado na maioria dos ambientes já. Para instruções manuais sobre como atualizar, veja o [post de anúncio](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html).
 
 </Note>
 
-
-To install the latest version of React and React DOM:
+Para instalar a versão mais recente do React e do React DOM:
 
 ```bash
 npm install react@beta react-dom@beta
 ```
 
-If you're using TypeScript, you also need to update the types. Once React 19 is released as stable, you can install the types as usual from `@types/react` and `@types/react-dom`.  During the beta period, the types are available in different packages which need to be enforced in your `package.json`:
+Se você estiver usando o TypeScript, também precisará atualizar os tipos. Uma vez que o React 19 seja lançado como estável, você pode instalar os tipos normalmente a partir de `@types/react` e `@types/react-dom`. Durante o período beta, os tipos estão disponíveis em pacotes diferentes que precisam ser forçados em seu `package.json`:
 
 ```json
 {
@@ -95,47 +92,45 @@ If you're using TypeScript, you also need to update the types. Once React 19 is 
 }
 ```
 
-We're also including a codemod for the most common replacements. See [TypeScript changes](#typescript-changes) below.
+Também estamos incluindo um codemod para as substituições mais comuns. Veja [Mudanças no TypeScript](#typescript-changes) abaixo.
 
+## Mudanças Disruptivas {/*breaking-changes*/}
 
-## Breaking changes {/*breaking-changes*/}
+### Erros no render não são relançados {/*errors-in-render-are-not-re-thrown*/}
 
-### Errors in render are not re-thrown {/*errors-in-render-are-not-re-thrown*/}
+Nas versões anteriores do React, erros lançados durante o render foram capturados e relançados. No DEV, também faríamos um log em `console.error`, resultando em logs de erro duplicados.
 
-In previous versions of React, errors thrown during render were caught and rethrown. In DEV, we would also log to `console.error`, resulting in duplicate error logs. 
+No React 19, melhoramos [como os erros são tratados](/blog/2024/04/25/react-19#error-handling) para reduzir a duplicação ao não relançar:
 
-In React 19, we've [improved how errors are handled](/blog/2024/04/25/react-19#error-handling) to reduce duplication by not re-throwing:
+- **Erros Não Capturados**: Erros que não são capturados por um Error Boundary são reportados para `window.reportError`.
+- **Erros Capturados**: Erros que são capturados por um Error Boundary são reportados para `console.error`.
 
-- **Uncaught Errors**: Errors that are not caught by an Error Boundary are reported to `window.reportError`.
-- **Caught Errors**: Errors that are caught by an Error Boundary are reported to `console.error`.
-
-This change should not impact most apps, but if your production error reporting relies on errors being re-thrown, you may need to update your error handling. To support this, we've added new methods to `createRoot` and `hydrateRoot` for custom error handling:
+Essa mudança não deve impactar a maioria dos aplicativos, mas se seu relatório de erros em produção depender de erros sendo relançados, você pode precisar atualizar seu tratamento de erros. Para suportar isso, adicionamos novos métodos a `createRoot` e `hydrateRoot` para tratamento de erros personalizado:
 
 ```js [[1, 2, "onUncaughtError"], [2, 5, "onCaughtError"]]
 const root = createRoot(container, {
   onUncaughtError: (error, errorInfo) => {
-    // ... log error report
+    // ... registrar relatório de erro
   },
   onCaughtError: (error, errorInfo) => {
-    // ... log error report
+    // ... registrar relatório de erro
   }
 });
 ```
 
-For more info, see the docs for [`createRoot`](https://react.dev/reference/react-dom/client/createRoot) and [`hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot).
+Para mais informações, veja a documentação sobre [`createRoot`](https://react.dev/reference/react-dom/client/createRoot) e [`hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot).
 
+### APIs React Obsoletas Removidas {/*removed-deprecated-react-apis*/}
 
-### Removed deprecated React APIs {/*removed-deprecated-react-apis*/}
+#### Removido: `propTypes` e `defaultProps` para funções {/*removed-proptypes-and-defaultprops*/}
+`PropTypes` foram obsoletos em [abril de 2017 (v15.5.0)](https://legacy.reactjs.org/blog/2017/04/07/react-v15.5.0.html#new-deprecation-warnings).
 
-#### Removed: `propTypes` and `defaultProps` for functions {/*removed-proptypes-and-defaultprops*/}
-`PropTypes` were deprecated in [April 2017 (v15.5.0)](https://legacy.reactjs.org/blog/2017/04/07/react-v15.5.0.html#new-deprecation-warnings). 
+No React 19, estamos removendo as verificações de `propType` do pacote React, e o uso delas será ignorado silenciosamente. Se você estiver usando `propTypes`, recomendamos migrar para TypeScript ou outra solução de verificação de tipos.
 
-In React 19, we're removing the `propType` checks from the React package, and using them will be silently ignored. If you're using `propTypes`, we recommend migrating to TypeScript or another type-checking solution.
-
-We're also removing `defaultProps` from function components in place of ES6 default parameters. Class components will continue to support `defaultProps` since there is no ES6 alternative.
+Estamos também removendo `defaultProps` dos componentes de função em vez de parâmetros padrão do ES6. Componentes de classe continuarão a suportar `defaultProps`, uma vez que não há alternativa no ES6.
 
 ```js
-// Before
+// Antes
 import PropTypes from 'prop-types';
 
 function Heading({text}) {
@@ -149,7 +144,7 @@ Heading.defaultProps = {
 };
 ```
 ```ts
-// After
+// Depois
 interface Props {
   text?: string;
 }
@@ -158,16 +153,16 @@ function Heading({text = 'Hello, world!'}: Props) {
 }
 ```
 
-#### Removed: Legacy Context using `contextTypes` and `getChildContext` {/*removed-removing-legacy-context*/}
+#### Removido: Contexto Legado usando `contextTypes` e `getChildContext` {/*removed-removing-legacy-context*/}
 
-Legacy Context was deprecated in [October 2018 (v16.6.0)](https://legacy.reactjs.org/blog/2018/10/23/react-v-16-6.html).
+O Contexto Legado foi obsoleto em [outubro de 2018 (v16.6.0)](https://legacy.reactjs.org/blog/2018/10/23/react-v-16-6.html).
 
-Legacy Context was only available in class components using the APIs `contextTypes` and `getChildContext`, and was replaced with `contextType` due to subtle bugs that were easy to miss. In React 19, we're removing Legacy Context to make React slightly smaller and faster.
+O Contexto Legado estava disponível apenas em componentes de classe usando as APIs `contextTypes` e `getChildContext`, e foi substituído por `contextType` devido a bugs sutis que eram fáceis de perder. No React 19, estamos removendo o Contexto Legado para que o React fique um pouco menor e mais rápido.
 
-If you're still using Legacy Context in class components, you'll need to migrate to the new `contextType` API:
+Se você ainda estiver usando o Contexto Legado em componentes de classe, precisará migrar para a nova API `contextType`:
 
 ```js {5-11,19-21}
-// Before
+// Antes
 import PropTypes from 'prop-types';
 
 class Parent extends React.Component {
@@ -196,7 +191,7 @@ class Child extends React.Component {
 ```
 
 ```js {2,7,9,15}
-// After
+// Depois
 const FooContext = React.createContext();
 
 class Parent extends React.Component {
@@ -218,15 +213,15 @@ class Child extends React.Component {
 }
 ```
 
-#### Removed: string refs {/*removed-string-refs*/}
-String refs were deprecated in [March, 2018 (v16.3.0)](https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html).
+#### Removido: refs de string {/*removed-string-refs*/}
+Refs de string foram obsoletas em [março de 2018 (v16.3.0)](https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html).
 
-Class components supported string refs before being replaced by ref callbacks due to [multiple downsides](https://github.com/facebook/react/issues/1373). In React 19, we're removing string refs to make React simpler and easier to understand.
+Os componentes de classe suportavam refs de string antes de serem substituídos por callbacks de ref devido a [vários inconvenientes](https://github.com/facebook/react/issues/1373). No React 19, estamos removendo refs de string para tornar o React mais simples e fácil de entender.
 
-If you're still using string refs in class components, you'll need to migrate to ref callbacks:
+Se você ainda estiver usando refs de string em componentes de classe, precisará migrar para callbacks de ref:
 
 ```js {4,8}
-// Before
+// Antes
 class MyComponent extends React.Component {
   componentDidMount() {
     this.refs.input.focus();
@@ -239,7 +234,7 @@ class MyComponent extends React.Component {
 ```
 
 ```js {4,8}
-// After
+// Depois
 class MyComponent extends React.Component {
   componentDidMount() {
     this.input.focus();
@@ -253,49 +248,49 @@ class MyComponent extends React.Component {
 
 <Note>
 
-To help with the migration, we will be publishing a [react-codemod](https://github.com/reactjs/react-codemod/#string-refs) to automatically replace string refs with `ref` callbacks. Follow [this PR](https://github.com/reactjs/react-codemod/pull/309) for updates and to try it out.
+Para ajudar na migração, publicaremos um [react-codemod](https://github.com/reactjs/react-codemod/#string-refs) para substituir automaticamente refs de string por callbacks de ref. Acompanhe [esta PR](https://github.com/reactjs/react-codemod/pull/309) para atualizações e para experimentar.
 
 </Note>
 
-#### Removed: Module pattern factories {/*removed-module-pattern-factories*/}
-Module pattern factories were deprecated in [August 2019 (v16.9.0)](https://legacy.reactjs.org/blog/2019/08/08/react-v16.9.0.html#deprecating-module-pattern-factories).
+#### Removido: Fábricas de padrão de módulo {/*removed-module-pattern-factories*/}
+Fábricas de padrão de módulo foram obsoletas em [agosto de 2019 (v16.9.0)](https://legacy.reactjs.org/blog/2019/08/08/react-v16.9.0.html#deprecating-module-pattern-factories).
 
-This pattern was rarely used and supporting it causes React to be slightly larger and slower than necessary. In React 19, we're removing support for module pattern factories, and you'll need to migrate to regular functions:
+Esse padrão era raramente utilizado e seu suporte faz com que o React fique um pouco maior e mais lento do que o necessário. No React 19, estamos removendo o suporte para fábricas de padrão de módulo, e você precisará migrar para funções regulares:
 
 ```js
-// Before
+// Antes
 function FactoryComponent() {
   return { render() { return <div />; } }
 }
 ```
 
 ```js
-// After
+// Depois
 function FactoryComponent() {
   return <div />;
 }
 ```
 
-#### Removed: `React.createFactory` {/*removed-createfactory*/}
-`createFactory` was deprecated in [February 2020 (v16.13.0)](https://legacy.reactjs.org/blog/2020/02/26/react-v16.13.0.html#deprecating-createfactory).
+#### Removido: `React.createFactory` {/*removed-createfactory*/}
+`createFactory` foi obsoleto em [fevereiro de 2020 (v16.13.0)](https://legacy.reactjs.org/blog/2020/02/26/react-v16.13.0.html#deprecating-createfactory).
 
-Using `createFactory` was common before broad support for JSX, but it's rarely used today and can be replaced with JSX. In React 19, we're removing `createFactory` and you'll need to migrate to JSX:
+Usar `createFactory` era comum antes do amplo suporte para JSX, mas é raramente utilizado hoje e pode ser substituído por JSX. No React 19, estamos removendo `createFactory` e você precisará migrar para JSX:
 
 ```js
-// Before
+// Antes
 import { createFactory } from 'react';
 
 const button = createFactory('button');
 ```
 
 ```js
-// After
+// Depois
 const button = <button />;
 ```
 
-#### Removed: `react-test-renderer/shallow` {/*removed-react-test-renderer-shallow*/}
+#### Removido: `react-test-renderer/shallow` {/*removed-react-test-renderer-shallow*/}
 
-In React 18, we updated `react-test-renderer/shallow` to re-export [react-shallow-renderer](https://github.com/enzymejs/react-shallow-renderer). In React 19, we're removing `react-test-render/shallow` to prefer installing the package directly:
+No React 18, atualizamos `react-test-renderer/shallow` para reexportar [react-shallow-renderer](https://github.com/enzymejs/react-shallow-renderer). No React 19, estamos removendo `react-test-render/shallow` para preferir a instalação do pacote diretamente:
 
 ```bash
 npm install react-shallow-renderer --save-dev
@@ -307,92 +302,89 @@ npm install react-shallow-renderer --save-dev
 
 <Note>
 
-##### Please reconsider shallow rendering {/*please-reconsider-shallow-rendering*/}
+##### Por favor, reconsidere a renderização superficial {/*please-reconsider-shallow-rendering*/}
 
-Shallow rendering depends on React internals and can block you from future upgrades. We recommend migrating your tests to [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/) or [@testing-library/react-native](https://callstack.github.io/react-native-testing-library/docs/getting-started). 
+A renderização superficial depende de internals do React e pode impedi-lo de futuras atualizações. Recomendamos migrar seus testes para [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/) ou [@testing-library/react-native](https://callstack.github.io/react-native-testing-library/docs/getting-started).
 
 </Note>
 
-### Removed deprecated React DOM APIs {/*removed-deprecated-react-dom-apis*/}
+### APIs React DOM Obsoletas Removidas {/*removed-deprecated-react-dom-apis*/}
 
-#### Removed: `react-dom/test-utils` {/*removed-react-dom-test-utils*/}
+#### Removido: `react-dom/test-utils` {/*removed-react-dom-test-utils*/}
 
-We've moved `act` from `react-dom/test-utils` to the `react` package:
+Movemos `act` de `react-dom/test-utils` para o pacote `react`:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-`ReactDOMTestUtils.act` is deprecated in favor of `React.act`. Import `act` from `react` instead of `react-dom/test-utils`. See https://react.dev/warnings/react-dom-test-utils for more info.
+`ReactDOMTestUtils.act` está obsoleto em favor de `React.act`. Importe `act` de `react` em vez de `react-dom/test-utils`. Veja https://react.dev/warnings/react-dom-test-utils para mais informações.
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
-To fix this warning, you can import `act` from `react`:
+Para corrigir este aviso, você pode importar `act` de `react`:
 
 ```diff
 - import {act} from 'react-dom/test-utils'
 + import {act} from 'react';
 ```
 
-All other `test-utils` functions have been removed. These utilities were uncommon, and made it too easy to depend on low level implementation details of your components and React. In React 19, these functions will error when called and their exports will be removed in a future version.
+Todas as outras funções de `test-utils` foram removidas. Essas utilidades eram incomuns e tornaram muito fácil depender de detalhes de implementação de baixo nível de seus componentes e do React. No React 19, essas funções gerarão erro quando chamadas e suas exportações serão removidas em uma versão futura.
 
-See the [warning page](https://react.dev/warnings/react-dom-test-utils) for alternatives.
+Veja a [página de avisos](https://react.dev/warnings/react-dom-test-utils) para alternativas.
 
-#### Removed: `ReactDOM.render` {/*removed-reactdom-render*/}
+#### Removido: `ReactDOM.render` {/*removed-reactdom-render*/}
 
-`ReactDOM.render` was deprecated in [March 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). In React 19, we're removing `ReactDOM.render` and you'll need to migrate to using [`ReactDOM.createRoot`](https://react.dev/reference/react-dom/client/createRoot):
+`ReactDOM.render` foi obsoleto em [março de 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). No React 19, estamos removendo `ReactDOM.render` e você precisará migrar para usar [`ReactDOM.createRoot`](https://react.dev/reference/react-dom/client/createRoot):
 
 ```js
-// Before
+// Antes
 import {render} from 'react-dom';
 render(<App />, document.getElementById('root'));
 
-// After
+// Depois
 import {createRoot} from 'react-dom/client';
 const root = createRoot(document.getElementById('root'));
 root.render(<App />);
 ```
 
-#### Removed: `ReactDOM.hydrate` {/*removed-reactdom-hydrate*/}
+#### Removido: `ReactDOM.hydrate` {/*removed-reactdom-hydrate*/}
 
-`ReactDOM.hydrate` was deprecated in [March 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). In React 19, we're removing `ReactDOM.hydrate` you'll need to migrate to using [`ReactDOM.hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot),
+`ReactDOM.hydrate` foi obsoleto em [março de 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). No React 19, estamos removendo `ReactDOM.hydrate` e você precisará migrar para usar [`ReactDOM.hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot),
 
 ```js
-// Before
+// Antes
 import {hydrate} from 'react-dom';
 hydrate(<App />, document.getElementById('root'));
 
-// After
+// Depois
 import {hydrateRoot} from 'react-dom/client';
 hydrateRoot(document.getElementById('root'), <App />);
 ```
 
+#### Removido: `unmountComponentAtNode` {/*removed-unmountcomponentatnode*/}
 
-#### Removed: `unmountComponentAtNode` {/*removed-unmountcomponentatnode*/}
-
-`ReactDOM.unmountComponentAtNode` was deprecated in [March 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). In React 19, you'll need to migrate to using `root.unmount()`.
-
+`ReactDOM.unmountComponentAtNode` foi obsoleto em [março de 2022 (v18.0.0)](https://react.dev/blog/2022/03/08/react-18-upgrade-guide). No React 19, você precisará migrar para usar `root.unmount()`.
 
 ```js
-// Before
+// Antes
 unmountComponentAtNode(document.getElementById('root'));
 
-// After
+// Depois
 root.unmount();
 ```
 
-For more see `root.unmount()` for [`createRoot`](https://react.dev/reference/react-dom/client/createRoot#root-unmount) and [`hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot#root-unmount).
+Para mais informações, veja `root.unmount()` para [`createRoot`](https://react.dev/reference/react-dom/client/createRoot#root-unmount) e [`hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot#root-unmount).
 
+#### Removido: `ReactDOM.findDOMNode` {/*removed-reactdom-finddomnode*/}
+`ReactDOM.findDOMNode` foi [obsoleto em outubro de 2018 (v16.6.0)](https://legacy.reactjs.org/blog/2018/10/23/react-v-16-6.html#deprecations-in-strictmode).
 
-#### Removed: `ReactDOM.findDOMNode` {/*removed-reactdom-finddomnode*/}
-`ReactDOM.findDOMNode` was [deprecated in October 2018 (v16.6.0)](https://legacy.reactjs.org/blog/2018/10/23/react-v-16-6.html#deprecations-in-strictmode). 
-
-We're removing `findDOMNode` because it was a legacy escape hatch that was slow to execute, fragile to refactoring, only returned the first child, and broke abstraction levels (see more [here](https://legacy.reactjs.org/docs/strict-mode.html#warning-about-deprecated-finddomnode-usage)). You can replace `ReactDOM.findDOMNode` with [DOM refs](/learn/manipulating-the-dom-with-refs):
+Estamos removendo `findDOMNode` porque era um escape hatch legado que era lento para executar, frágil a refatorações, retornava apenas o primeiro filho e quebrava níveis de abstração (veja mais [aqui](https://legacy.reactjs.org/docs/strict-mode.html#warning-about-deprecated-finddomnode-usage)). Você pode substituir `ReactDOM.findDOMNode` por [refs do DOM](/learn/manipulating-the-dom-with-refs):
 
 ```js
-// Before
+// Antes
 import {findDOMNode} from 'react-dom';
 
 function AutoselectingInput() {
@@ -406,7 +398,7 @@ function AutoselectingInput() {
 ```
 
 ```js
-// After
+// Depois
 function AutoselectingInput() {
   const ref = useRef(null);
   useEffect(() => {
@@ -417,47 +409,47 @@ function AutoselectingInput() {
 }
 ```
 
-## New deprecations {/*new-deprecations*/}
+## Novas desativações {/*new-deprecations*/}
 
-### Deprecated: `element.ref` {/*deprecated-element-ref*/}
+### Obsoleto: `element.ref` {/*deprecated-element-ref*/}
 
-React 19 supports [`ref` as a prop](/blog/2024/04/25/react-19#ref-as-a-prop), so we're deprecating the `element.ref` in place of `element.props.ref`.
+O React 19 suporta [`ref` como uma prop](/blog/2024/04/25/react-19#ref-as-a-prop), então estamos desativando o `element.ref` em vez de `element.props.ref`.
 
-Accessing `element.ref` will warn:
+Acessar `element.ref` irá gerar um aviso:
 
 <ConsoleBlockMulti>
 
 <ConsoleLogLine level="error">
 
-Accessing element.ref is no longer supported. ref is now a regular prop. It will be removed from the JSX Element type in a future release.
+Acessar element.ref não é mais suportado. ref agora é uma prop comum. Será removido do tipo Element JSX em uma versão futura.
 
 </ConsoleLogLine>
 
 </ConsoleBlockMulti>
 
-### Deprecated: `react-test-renderer` {/*deprecated-react-test-renderer*/}
+### Obsoleto: `react-test-renderer` {/*deprecated-react-test-renderer*/}
 
-We are deprecating `react-test-renderer` because it implements its own renderer environment that doesn't match the environment users use, promotes testing implementation details, and relies on introspection of React's internals.
+Estamos desativando `react-test-renderer` porque ele implementa seu próprio ambiente de renderização que não corresponde ao ambiente que os usuários usam, promove a testagem de detalhes de implementação, e depende da introspecção dos internos do React.
 
-The test renderer was created before there were more viable testing strategies available like [React Testing Library](https://testing-library.com), and we now recommend using a modern testing library instead.
+O test renderer foi criado antes de existirem estratégias de teste mais viáveis disponíveis, como [React Testing Library](https://testing-library.com), e agora recomendamos usar uma biblioteca de teste moderna em vez disso.
 
-In React 19, `react-test-renderer` logs a deprecation warning, and has switched to concurrent rendering. We recommend migrating your tests to [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/) or [@testing-library/react-native](https://callstack.github.io/react-native-testing-library/docs/getting-started) for a modern and well supported testing experience.
+No React 19, `react-test-renderer` gera um aviso de obsolescência e foi switchado para renderização concorrente. Recomendamos migrar seus testes para [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/) ou [@testing-library/react-native](https://callstack.github.io/react-native-testing-library/docs/getting-started) para uma experiência de teste moderna e bem suportada.
 
-## Notable changes {/*notable-changes*/}
+## Mudanças Notáveis {/*notable-changes*/}
 
-### StrictMode changes {/*strict-mode-improvements*/}
+### Mudanças no StrictMode {/*strict-mode-improvements*/}
 
-React 19 includes several fixes and improvements to Strict Mode.
+O React 19 inclui várias correções e melhorias ao Strict Mode.
 
-When double rendering in Strict Mode in development, `useMemo` and `useCallback` will reuse the memoized results from the first render during the second render. Components that are already Strict Mode compatible should not notice a difference in behavior.
+Ao renderizar duas vezes no Strict Mode em desenvolvimento, `useMemo` e `useCallback` reutilizarão os resultados memorizados da primeira renderização durante a segunda renderização. Componentes que já são compatíveis com o Strict Mode não deverão notar diferenças no comportamento.
 
-As with all Strict Mode behaviors, these features are designed to proactively surface bugs in your components during development so you can fix them before they are shipped to production. For example, during development, Strict Mode will double-invoke ref callback functions on initial mount, to simulate what happens when a mounted component is replaced by a Suspense fallback.
+Como com todos os comportamentos do Strict Mode, esses recursos são projetados para expor proativamente bugs em seus componentes durante o desenvolvimento, para que você possa corrigi-los antes de serem enviados para produção. Por exemplo, durante o desenvolvimento, o Strict Mode invocará duas vezes funções de callbacks de ref na montagem inicial, para simular o que acontece quando um componente montado é substituído por um fallback do Suspense.
 
-### UMD builds removed {/*umd-builds-removed*/}
+### Builds UMD removidas {/*umd-builds-removed*/}
 
-UMD was widely used in the past as a convenient way to load React without a build step. Now, there are modern alternatives for loading modules as scripts in HTML documents. Starting with React 19, React will no longer produce UMD builds to reduce the complexity of its testing and release process. 
+UMD era amplamente utilizado no passado como uma maneira conveniente de carregar o React sem uma etapa de construção. Agora, existem alternativas modernas para carregar módulos como scripts em documentos HTML. A partir do React 19, o React não produzirá mais builds UMD para reduzir a complexidade de seu processo de testes e lançamentos.
 
-To load React 19 with a script tag, we recommend using an ESM-based CDN such as [esm.sh](https://esm.sh/).
+Para carregar o React 19 com uma tag de script, recomendamos usar um CDN baseado em ESM, como [esm.sh](https://esm.sh/).
 
 ```html
 <script type="module">
@@ -467,83 +459,81 @@ To load React 19 with a script tag, we recommend using an ESM-based CDN such as 
 </script>
 ```
 
-### Libraries depending on React internals may block upgrades {/*libraries-depending-on-react-internals-may-block-upgrades*/}
+### Bibliotecas dependendo de internos do React podem bloquear atualizações {/*libraries-depending-on-react-internals-may-block-upgrades*/}
 
-This release includes changes to React internals that may impact libraries that ignore our pleas to not use internals like `SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED`. These changes are necessary to land improvements in React 19, and will not break libraries that follow our guidelines.
+Esta versão inclui mudanças nos internos do React que podem impactar bibliotecas que ignoram nossas solicitações para não usar internos como `SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED`. Essas mudanças são necessárias para realizar melhorias no React 19 e não quebrarão bibliotecas que seguem nossas diretrizes.
 
-Based on our [Versioning Policy](https://react.dev/community/versioning-policy#what-counts-as-a-breaking-change), these updates are not listed as breaking changes, and we are not including docs for how to upgrade them. The recommendation is to remove any code that depends on internals.
+Com base em nossa [Política de Versionamento](https://react.dev/community/versioning-policy#what-counts-as-a-breaking-change), essas atualizações não estão listadas como mudanças disruptivas, e não estamos incluindo documentações sobre como atualizá-las. A recomendação é remover qualquer código que dependa de internos.
 
-To reflect the impact of using internals, we have renamed the `SECRET_INTERNALS` suffix to: 
+Para refletir o impacto do uso de internos, renomeamos o sufixo `SECRET_INTERNALS` para:
 
 `_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE`
 
-In the future we will more aggressively block accessing internals from React to discourage usage and ensure users are not blocked from upgrading.
+No futuro, bloquearemos mais agressivamente o acesso a internos do React para desencorajar o uso e garantir que os usuários não fiquem bloqueados em atualizações.
 
-## TypeScript changes {/*typescript-changes*/}
+## Mudanças no TypeScript {/*typescript-changes*/}
 
-### Removed deprecated TypeScript types {/*removed-deprecated-typescript-types*/}
+### Tipos TypeScript obsoletos removidos {/*removed-deprecated-typescript-types*/}
 
-We've cleaned up the TypeScript types based on the removed APIs in React 19. Some of the removed have types been moved to more relevant packages, and others are no longer needed to describe React's behavior.
+Limparamos os tipos do TypeScript com base nas APIs removidas no React 19. Alguns dos tipos removidos foram movidos para pacotes mais relevantes e outros não são mais necessários para descrever o comportamento do React.
 
 <Note>
-We've published [`types-react-codemod`](https://github.com/eps1lon/types-react-codemod/) to migrate most type related breaking changes:
+Publicamos [`types-react-codemod`](https://github.com/eps1lon/types-react-codemod/) para migrar a maioria das mudanças disruptivas relacionadas a tipos:
 
 ```bash
-npx types-react-codemod@latest preset-19 ./path-to-app
+npx types-react-codemod@latest preset-19 ./caminho-para-o-aplicativo
 ```
 
-If you have a lot of unsound access to `element.props`, you can run this additional codemod:
+Se você tiver muito acesso inseguro a `element.props`, pode rodar este codemod adicional:
 
 ```bash
-npx types-react-codemod@latest react-element-default-any-props ./path-to-your-react-ts-files
+npx types-react-codemod@latest react-element-default-any-props ./caminho-para-seus-arquivos-react-ts
 ```
 
 </Note>
 
-Check out [`types-react-codemod`](https://github.com/eps1lon/types-react-codemod/) for a list of supported replacements. If you feel a codemod is missing, it can be tracked in the [list of missing React 19 codemods](https://github.com/eps1lon/types-react-codemod/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22React+19%22+label%3Aenhancement).
+Veja [`types-react-codemod`](https://github.com/eps1lon/types-react-codemod/) para uma lista de substituições suportadas. Se você sentir que um codemod está faltando, isso pode ser rastreado na [lista de codemods do React 19 que estão faltando](https://github.com/eps1lon/types-react-codemod/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22React+19%22+label%3Aenhancement).
 
+### Limpezas de `ref` necessárias {/*ref-cleanup-required*/}
 
-### `ref` cleanups required {/*ref-cleanup-required*/}
+_Esta mudança está incluída no preset de codemod `react-19` como [`no-implicit-ref-callback-return`](https://github.com/eps1lon/types-react-codemod/#no-implicit-ref-callback-return)._
 
-_This change is included in the `react-19` codemod preset as [`no-implicit-ref-callback-return
-`](https://github.com/eps1lon/types-react-codemod/#no-implicit-ref-callback-return)._
-
-Due to the introduction of ref cleanup functions, returning anything else from a ref callback will now be rejected by TypeScript. The fix is usually to stop using implicit returns:
+Devido à introdução de funções de limpeza de ref, retornar qualquer outra coisa de um callback de ref agora será rejeitado pelo TypeScript. A correção geralmente é parar de usar retornos implícitos:
 
 ```diff [[1, 1, "("], [1, 1, ")"], [2, 2, "{", 15], [2, 2, "}", 1]]
 - <div ref={current => (instance = current)} />
 + <div ref={current => {instance = current}} />
 ```
 
-The original code returned the instance of the `HTMLDivElement` and TypeScript wouldn't know if this was supposed to be a cleanup function or not.
+O código original retornava a instância de `HTMLDivElement` e o TypeScript não saberia se isso deveria ser uma função de limpeza ou não.
 
-### `useRef` requires an argument {/*useref-requires-argument*/}
+### `useRef` requer um argumento {/*useref-requires-argument*/}
 
-_This change is included in the `react-19` codemod preset as [`refobject-defaults`](https://github.com/eps1lon/types-react-codemod/#refobject-defaults)._
+_Esta mudança está incluída no preset de codemod `react-19` como [`refobject-defaults`](https://github.com/eps1lon/types-react-codemod/#refobject-defaults)._
 
-A long-time complaint of how TypeScript and React work has been `useRef`. We've changed the types so that `useRef` now requires an argument. This significantly simplifies its type signature. It'll now behave more like `createContext`.
+Uma reclamação de longa data sobre como TypeScript e React funcionam tem sido o `useRef`. Mudamos os tipos para que `useRef` agora exija um argumento. Isso simplifica significativamente sua assinatura de tipo. Agora se comportará mais como `createContext`.
 
 ```ts
-// @ts-expect-error: Expected 1 argument but saw none
+// @ts-expect-error: Esperado 1 argumento, mas não houve nenhum
 useRef();
-// Passes
+// Passa
 useRef(undefined);
-// @ts-expect-error: Expected 1 argument but saw none
+// @ts-expect-error: Esperado 1 argumento, mas não houve nenhum
 createContext();
-// Passes
+// Passa
 createContext(undefined);
 ```
 
-This now also means that all refs are mutable. You'll no longer hit the issue where you can't mutate a ref because you initialised it with `null`:
+Isso agora também significa que todas as refs são mutáveis. Você não encontrará mais o problema onde você não pode mutar uma ref porque a inicializou como `null`:
 
 ```ts
 const ref = useRef<number>(null);
 
-// Cannot assign to 'current' because it is a read-only property
+// Não é possível atribuir a 'current' porque é uma propriedade de somente leitura
 ref.current = 1;
 ```
 
-`MutableRef` is now deprecated in favor of a single `RefObject` type which `useRef` will always return:
+`MutableRef` agora é obsoleto em favor de um único tipo `RefObject` que `useRef` sempre retornará:
 
 ```ts
 interface RefObject<T> {
@@ -553,36 +543,36 @@ interface RefObject<T> {
 declare function useRef<T>: RefObject<T>
 ```
 
-`useRef` still has a convenience overload for `useRef<T>(null)` that automatically returns `RefObject<T | null>`. To ease migration due to the required argument for `useRef`, a convenience overload for `useRef(undefined)` was added that automatically returns `RefObject<T | undefined>`.
+`useRef` ainda possui uma sobrecarga de conveniência para `useRef<T>(null)` que automaticamente retorna `RefObject<T | null>`. Para facilitar a migração devido ao argumento requerido para `useRef`, foi adicionada uma sobrecarga de conveniência para `useRef(undefined)` que automaticamente retorna `RefObject<T | undefined>`.
 
-Check out [[RFC] Make all refs mutable](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64772) for prior discussions about this change.
+Veja [[RFC] Make all refs mutable](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64772) para discussões anteriores sobre essa mudança.
 
-### Changes to the `ReactElement` TypeScript type {/*changes-to-the-reactelement-typescript-type*/}
+### Mudanças no tipo TypeScript `ReactElement` {/*changes-to-the-reactelement-typescript-type*/}
 
-_This change is included in the [`react-element-default-any-props`](https://github.com/eps1lon/types-react-codemod#react-element-default-any-props) codemod._
+_Esta mudança está incluída no codemod [`react-element-default-any-props`](https://github.com/eps1lon/types-react-codemod#react-element-default-any-props)._
 
-The `props` of React elements now default to `unknown` instead of `any` if the element is typed as `ReactElement`. This does not affect you if you pass a type argument to `ReactElement`:
+As `props` de elementos React agora defaultam para `unknown` em vez de `any` se o elemento for tipado como `ReactElement`. Isso não afeta você se você passar um argumento de tipo para `ReactElement`:
 
 ```ts
 type Example2 = ReactElement<{ id: string }>["props"];
 //   ^? { id: string }
 ```
 
-But if you relied on the default, you now have to handle `unknown`:
+Mas se você confiou no padrão, agora você terá que lidar com `unknown`:
 
 ```ts
 type Example = ReactElement["props"];
-//   ^? Before, was 'any', now 'unknown'
+//   ^? Antes, era 'any', agora 'unknown'
 ```
 
-You should only need it if you have a lot of legacy code relying on unsound access of element props. Element introspection only exists as an escape hatch, and you should make it explicit that your props access is unsound via an explicit `any`.
+Você só precisa disso se tiver muito código legado dependendo do acesso inseguro às props do elemento. A introspecção de elementos existe apenas como um escape hatch, e você deve deixar explícito que o seu acesso às props é inseguro através de um `any` explícito.
 
-### The JSX namespace in TypeScript {/*the-jsx-namespace-in-typescript*/}
-This change is included in the `react-19` codemod preset as [`scoped-jsx`](https://github.com/eps1lon/types-react-codemod#scoped-jsx)
+### O namespace JSX no TypeScript {/*the-jsx-namespace-in-typescript*/}
+Essa mudança está incluída no preset de codemod `react-19` como [`scoped-jsx`](https://github.com/eps1lon/types-react-codemod#scoped-jsx).
 
-A long-time request is to remove the global `JSX` namespace from our types in favor of `React.JSX`. This helps prevent pollution of global types which prevents conflicts between different UI libraries that leverage JSX.
+Um pedido de longa data é remover o namespace global `JSX` de nossos tipos em favor de `React.JSX`. Isso ajuda a prevenir a poluição de tipos globais, o que impede conflitos entre diferentes bibliotecas de UI que utilizam JSX.
 
-You'll now need to wrap module augmentation of the JSX namespace in `declare module "....":
+Agora você precisará envolver a augmentação de módulo do namespace JSX em `declare module "....":
 
 ```diff
 // global.d.ts
@@ -597,34 +587,34 @@ You'll now need to wrap module augmentation of the JSX namespace in `declare mod
 + }
 ```
 
-The exact module specifier depends on the JSX runtime you specified in the `compilerOptions` of your `tsconfig.json`:
+O especificador de módulo exato depende do runtime JSX que você especificou nas `compilerOptions` de seu `tsconfig.json`:
 
-- For `"jsx": "react-jsx"` it would be `react/jsx-runtime`.
-- For `"jsx": "react-jsxdev"` it would be `react/jsx-dev-runtime`.
-- For `"jsx": "react"` and `"jsx": "preserve"` it would be `react`.
+- Para `"jsx": "react-jsx"` seria `react/jsx-runtime`.
+- Para `"jsx": "react-jsxdev"` seria `react/jsx-dev-runtime`.
+- Para `"jsx": "react"` e `"jsx": "preserve"` seria `react`.
 
-### Better `useReducer` typings {/*better-usereducer-typings*/}
+### Melhores tipagens para `useReducer` {/*better-usereducer-typings*/}
 
-`useReducer` now has improved type inference thanks to [@mfp22](https://github.com/mfp22).
+`useReducer` agora tem inferência de tipo melhorada graças a [@mfp22](https://github.com/mfp22).
 
-However, this required a breaking change where `useReducer` doesn't accept the full reducer type as a type parameter but instead either needs none (and rely on contextual typing) or needs both the state and action type.
+No entanto, isso exigiu uma mudança disruptiva onde `useReducer` não aceita o tipo completo do redutor como um parâmetro de tipo, mas precisa de nenhum (e confiar na tipagem contextual) ou precisa tanto do estado quanto do tipo de ação.
 
-The new best practice is _not_ to pass type arguments to `useReducer`.
+A nova melhor prática é _não_ passar argumentos de tipo para `useReducer`.
 ```diff
 - useReducer<React.Reducer<State, Action>>(reducer)
 + useReducer(reducer)
 ```
-This may not work in edge cases where you can explicitly type the state and action, by passing in the `Action` in a tuple:
+Isso pode não funcionar em casos extremos onde você pode tipar explicitamente o estado e a ação, passando o `Action` em uma tupla:
 ```diff
 - useReducer<React.Reducer<State, Action>>(reducer)
 + useReducer<State, [Action]>(reducer)
 ```
-If you define the reducer inline, we encourage to annotate the function parameters instead:
+Se você definir o redutor inline, encorajamos você a anotar os parâmetros da função em vez disso:
 ```diff
 - useReducer<React.Reducer<State, Action>>((state, action) => state)
 + useReducer((state: State, action: Action) => state)
 ```
-This is also what you'd also have to do if you move the reducer outside of the `useReducer` call:
+Isso é também o que você teria que fazer se mover o redutor para fora da chamada `useReducer`:
 
 ```ts
 const reducer = (state: State, action: Action) => state;
@@ -632,27 +622,27 @@ const reducer = (state: State, action: Action) => state;
 
 ## Changelog {/*changelog*/}
 
-### Other breaking changes {/*other-breaking-changes*/}
+### Outras mudanças disruptivas {/*other-breaking-changes*/}
 
-- **react-dom**: Error for javascript URLs in src/href [#26507](https://github.com/facebook/react/pull/26507)
-- **react-dom**: Remove `errorInfo.digest` from `onRecoverableError` [#28222](https://github.com/facebook/react/pull/28222)
-- **react-dom**: Remove `unstable_flushControlled` [#26397](https://github.com/facebook/react/pull/26397)
-- **react-dom**: Remove `unstable_createEventHandle` [#28271](https://github.com/facebook/react/pull/28271)
-- **react-dom**: Remove `unstable_renderSubtreeIntoContainer` [#28271](https://github.com/facebook/react/pull/28271)
-- **react-dom**: Remove `unstable_runWithPrioirty` [#28271](https://github.com/facebook/react/pull/28271)
-- **react-is**: Remove deprecated methods from `react-is` [28224](https://github.com/facebook/react/pull/28224)
+- **react-dom**: Erro para URLs javascript em src/href [#26507](https://github.com/facebook/react/pull/26507)
+- **react-dom**: Remover `errorInfo.digest` de `onRecoverableError` [#28222](https://github.com/facebook/react/pull/28222)
+- **react-dom**: Remover `unstable_flushControlled` [#26397](https://github.com/facebook/react/pull/26397)
+- **react-dom**: Remover `unstable_createEventHandle` [#28271](https://github.com/facebook/react/pull/28271)
+- **react-dom**: Remover `unstable_renderSubtreeIntoContainer` [#28271](https://github.com/facebook/react/pull/28271)
+- **react-dom**: Remover `unstable_runWithPrioirty` [#28271](https://github.com/facebook/react/pull/28271)
+- **react-is**: Remover métodos obsoletos de `react-is` [28224](https://github.com/facebook/react/pull/28224)
 
-### Other notable changes {/*other-notable-changes*/}
+### Outras mudanças notáveis {/*other-notable-changes*/}
 
-- **react**: Batch sync, default and continuous lanes [#25700](https://github.com/facebook/react/pull/25700)
-- **react**: Don't prerender siblings of suspended component [#26380](https://github.com/facebook/react/pull/26380)
-- **react**: Detect infinite update loops caused by render phase updates [#26625](https://github.com/facebook/react/pull/26625)
-- **react-dom**: Transitions in popstate are now synchronous [#26025](https://github.com/facebook/react/pull/26025)
-- **react-dom**: Remove layout effect warning during SSR [#26395](https://github.com/facebook/react/pull/26395)
-- **react-dom**: Warn and don’t set empty string for src/href (except anchor tags) [#28124](https://github.com/facebook/react/pull/28124)
+- **react**: Lanes de batch sync, default e contínuas [#25700](https://github.com/facebook/react/pull/25700)
+- **react**: Não pré-renderizar irmãos de componente suspenso [#26380](https://github.com/facebook/react/pull/26380)
+- **react**: Detectar loops de atualização infinitos causados por atualizações na fase de renderização [#26625](https://github.com/facebook/react/pull/26625)
+- **react-dom**: Transições em popstate agora são síncronas [#26025](https://github.com/facebook/react/pull/26025)
+- **react-dom**: Remover aviso de efeito de layout durante SSR [#26395](https://github.com/facebook/react/pull/26395)
+- **react-dom**: Avisar e não definir string vazia para src/href (exceto tags de âncora) [#28124](https://github.com/facebook/react/pull/28124)
 
-We'll publish the full changelog with the stable release of React 19.
+Publicaremos o changelog completo com o lançamento estável do React 19.
 
 ---
 
-Thanks to [Andrew Clark](https://twitter.com/acdlite), [Eli White](https://twitter.com/Eli_White), [Jack Pope](https://github.com/jackpope), [Jan Kassens](https://github.com/kassens), [Josh Story](https://twitter.com/joshcstory), [Matt Carroll](https://twitter.com/mattcarrollcode), [Noah Lemen](https://twitter.com/noahlemen), [Sophie Alpert](https://twitter.com/sophiebits), and [Sebastian Silbermann](https://twitter.com/sebsilbermann) for reviewing and editing this post.
+Agradecimentos a [Andrew Clark](https://twitter.com/acdlite), [Eli White](https://twitter.com/Eli_White), [Jack Pope](https://github.com/jackpope), [Jan Kassens](https://github.com/kassens), [Josh Story](https://twitter.com/joshcstory), [Matt Carroll](https://twitter.com/mattcarrollcode), [Noah Lemen](https://twitter.com/noahlemen), [Sophie Alpert](https://twitter.com/sophiebits) e [Sebastian Silbermann](https://twitter.com/sebsilbermann) por revisar e editar este post.


### PR DESCRIPTION
This pull request contains a translation of the referenced page into Portuguese (pt-BR). The translation was generated using OpenAI _(model `gpt-4o-mini`)_.

Refer to the [source repository](https://github.com/NivaldoFarias/translate-react) workflow that generated this translation for more details.

Feel free to review and suggest any improvements to the translation.