### PR TITLE
Translate `generic.md` to pt-br

### DIFF
--- a/src/content/errors/generic.md
+++ b/src/content/errors/generic.md
@@ -1,11 +1,11 @@
-<Intro>
+<Introdutório>
 
-In the minified production build of React, we avoid sending down full error messages in order to reduce the number of bytes sent over the wire.
+Na build de produção minificada do React, evitamos enviar mensagens de erro completas para reduzir o número de bytes enviados pela rede.
 
 </Intro>
 
-We highly recommend using the development build locally when debugging your app since it tracks additional debug info and provides helpful warnings about potential problems in your apps, but if you encounter an exception while using the production build, this page will reassemble the original error message.
+Recomendamos fortemente usar a build de desenvolvimento localmente ao depurar seu aplicativo, já que ela rastreia informações de depuração adicionais e fornece avisos úteis sobre problemas potenciais em seus aplicativos. Mas se você encontrar uma exceção enquanto usa a build de produção, esta página irá reassemblar a mensagem de erro original.
 
-The full text of the error you just encountered is:
+O texto completo do erro que você acabou de encontrar é:
 
 <ErrorDecoder />


### PR DESCRIPTION
This pull request contains a translation of the referenced page into Portuguese (pt-BR). The translation was generated using OpenAI _(model `gpt-4o-mini`)_.

Refer to the [source repository](https://github.com/NivaldoFarias/translate-react) workflow that generated this translation for more details.

Feel free to review and suggest any improvements to the translation.