### PR TITLE
Translate `introducing-react-dev.md` to pt-BR

### DIFF
--- a/src/content/blog/2023/03/16/introducing-react-dev.md
+++ b/src/content/blog/2023/03/16/introducing-react-dev.md
@@ -1,8 +1,179 @@
----
-title: "Apresentando react.dev"
-author: Dan Abramov and Rachel Nabors
-date: 2023/03/16
-description: Hoje estamos entusiasmados em lançar o react.dev, o novo lar do React e sua documentação. Neste post, gostaríamos de fazer um tour pelo novo site.
+# Apresentando react.dev
+
+Este documento descreve as regras que devem ser aplicadas para **todos** os idiomas.
+Quando estiver se referindo ao próprio `React`, use `o React`.
+
+## IDs dos Títulos
+
+Todos os títulos possuem IDs explícitos como abaixo:
+
+```md
+## Tente React {#try-react}
+```
+
+**Não** traduza estes IDs! Eles são usado para navegação e quebrarão se o documento for um link externo, como:
+
+```md
+Veja a [seção iniciando](/getting-started#try-react) para mais informações.
+```
+
+✅ FAÇA:
+
+```md
+## Tente React {#try-react}
+```
+
+❌ NÃO FAÇA:
+
+```md
+## Tente React {#tente-react}
+```
+
+Isto quebraria o link acima.
+
+## Texto em Blocos de Código
+
+Mantenha o texto em blocos de código sem tradução, exceto para os comentários. Você pode optar por traduzir o texto em strings, mas tenha cuidado para não traduzir strings que se refiram ao código!
+
+Exemplo:
+
+```js
+// Example
+const element = <h1>Hello, world</h1>;
+ReactDOM.render(element, document.getElementById('root'));
+```
+
+✅ FAÇA:
+
+```js
+// Exemplo
+const element = <h1>Hello, world</h1>;
+ReactDOM.render(element, document.getElementById('root'));
+```
+
+✅ PERMITIDO:
+
+```js
+// Exemplo
+const element = <h1>Olá mundo</h1>;
+ReactDOM.render(element, document.getElementById('root'));
+```
+
+❌ NÃO FAÇA:
+
+```js
+// Exemplo
+const element = <h1>Olá mundo</h1>;
+// "root" se refere a um ID de elemento.
+// NÃO TRADUZA
+ReactDOM.render(element, document.getElementById('raiz'));
+```
+
+❌ DEFINITIVAMENTE NÃO FAÇA:
+
+```js
+// Exemplo
+const elemento = <h1>Olá mundo</h1>;
+ReactDOM.renderizar(elemento, documento.obterElementoPorId('raiz'));
+```
+
+## Links Externos
+
+Se um link externo se referir a um artigo no [MDN] or [Wikipedia] e se houver uma versão traduzida em seu idioma em uma qualidade decente, opte por usar a versão traduzida.
+
+[mdn]: https://developer.mozilla.org/pt-BR/
+[wikipedia]: https://pt.wikipedia.org/wiki/Wikipédia:Página_principal
+
+Exemplo:
+
+```md
+React elements are [immutable](https://en.wikipedia.org/wiki/Immutable_object).
+```
+
+✅ OK:
+
+```md
+Elementos React são [imutáveis](https://pt.wikipedia.org/wiki/Objeto_imutável).
+```
+
+Para links que não possuem tradução (Stack Overflow, vídeos do YouTube, etc.), simplesmente use o link original.
+
+## Traduções Comuns
+
+Sugestões de palavras e termos:
+
+| Palavra/Termo original | Sugestão                               |
+| ---------------------- | -------------------------------------- |
+| assertion              | asserção                               |
+| at the top level       | na raiz                                |
+| browser                | navegador                              |
+| bubbling               | propagar                               |
+| bug                    | erro                                   |
+| caveats                | ressalvas                              |
+| class component        | componente de classe                   |
+| class                  | classe                                 |
+| client                 | cliente                                |
+| client-side            | lado do cliente                        |
+| container              | contêiner                              |
+| context                | contexto                               |
+| controlled component   | componente controlado                  |
+| debugging              | depuração                              |
+| DOM node               | nó do DOM                              |
+| event handler          | manipulador de eventos (event handler) |
+| function component     | componente de função                   |
+| handler                | manipulador                            |
+| helper function        | função auxiliar                        |
+| high-order components  | componente de alta-ordem               |
+| key                    | chave                                  |
+| library                | biblioteca                             |
+| lowercase              | minúscula(s) / caixa baixa             |
+| package                | pacote                                 |
+| React element          | Elemento React                         |
+| React fragment         | Fragmento React                        |
+| render                 | renderizar (verb), renderizado (noun)  |
+| server                 | servidor                               |
+| server-side            | lado do servidor                       |
+| siblings               | irmãos                                 |
+| stateful component     | componente com estado                  |
+| stateful logic         | lógica com estado                      |
+| to assert              | afirmar                                |
+| to wrap                | encapsular                             |
+| troubleshooting        | solução de problemas                   |
+| uncontrolled component | componente não controlado              |
+| uppercase              | maiúscula(s) / caixa alta              |
+
+## Conteúdo que não deve ser traduzido
+
+- array
+- arrow function
+- bind
+- bundle
+- bundler
+- callback
+- camelCase
+- DOM
+- event listener
+- framework
+- hook
+- log
+- mock
+- portal
+- props
+| ref
+| release
+| script
+| single-page-apps
+| state
+| string
+| string literal
+| subscribe
+| subscription
+| template literal
+| timestamps
+| UI
+| watcher
+| widgets
+| wrapper
 ---
 
 16 de março de 2023 por [Dan Abramov](https://bsky.app/profile/danabra.mov) e [Rachel Nabors](https://twitter.com/rachelnabors)
@@ -178,7 +349,8 @@ function calculateWinner(squares) {
 }
 ```
 
-```css src/styles.css
+```css
+/* Exemplo */
 * {
   box-sizing: border-box;
 }
@@ -237,7 +409,7 @@ O exemplo acima é uma *sandbox*. Adicionamos muitas sandboxes—mais de 600!—
 
 Gostaríamos que todos no mundo tivessem a mesma oportunidade de aprender React de graça por conta própria.
 
-É por isso que a seção Aprenda está organizada como um curso individualizado dividido em capítulos. Os dois primeiros capítulos descrevem os fundamentos do React. Se você é novo no React, ou quer refrescar sua memória, comece aqui:
+É por isso que a seção Aprender está organizada como um curso individualizado dividido em capítulos. Os dois primeiros capítulos descrevem os fundamentos do React. Se você é novo no React, ou quer refrescar sua memória, comece aqui:
 
 - **[Descrevendo a IU](/learn/describing-the-ui)** ensina a exibir informações com componentes.
 - **[Adicionando Interatividade](/learn/adding-interactivity)** ensina como atualizar a tela em resposta à entrada do usuário.
@@ -266,6 +438,7 @@ Use o operador condicional (`cond ? a : b`) para renderizar um ❌ se `isPacked`
 <Sandpack>
 
 ```js
+// Exemplo
 function Item({ name, isPacked }) {
   return (
     <li className="item">
@@ -304,6 +477,7 @@ export default function PackingList() {
 <Sandpack>
 
 ```js
+// Exemplo
 function Item({ name, isPacked }) {
   return (
     <li className="item">
@@ -352,6 +526,7 @@ Não se esqueça de adicionar um espaço entre as duas etiquetas!
 <Sandpack>
 
 ```js
+// Exemplo
 function Item({ name, importance }) {
   return (
     <li className="item">
@@ -392,6 +567,7 @@ Isso deve resolver o problema:
 <Sandpack>
 
 ```js
+// Exemplo
 function Item({ name, importance }) {
   return (
     <li className="item">
@@ -480,6 +656,7 @@ Neste exemplo, a variável state `count` armazena um número. Ao clicar no botã
 <Sandpack>
 
 ```js
+// Exemplo
 import { useState } from 'react';
 
 export default function Counter() {
@@ -508,6 +685,7 @@ Neste exemplo, a variável state `text` armazena uma string. Quando você digita
 <Sandpack>
 
 ```js
+// Exemplo
 import { useState } from 'react';
 
 export default function MyInput() {
@@ -540,6 +718,7 @@ Neste exemplo, a variável state `liked` armazena um valor booleano. Quando voc�
 <Sandpack>
 
 ```js
+// Exemplo
 import { useState } from 'react';
 
 export default function MyCheckbox() {
@@ -576,6 +755,7 @@ Você pode declarar mais de uma variável state no mesmo componente. Cada variá
 <Sandpack>
 
 ```js
+// Exemplo
 import { useState } from 'react';
 
 export default function Form() {
@@ -598,6 +778,7 @@ export default function Form() {
 ```
 
 ```css
+/* Exemplo */
 button { display: block; margin-top: 10px; }
 ```
 


### PR DESCRIPTION
This pull request contains a translation of the referenced page into Portuguese (pt-BR). The translation was generated using OpenRouter _(model `google/gemini-2.0-flash-lite-preview-02-05:free`)_.

Refer to the [source repository](https://github.com/NivaldoFarias/translate-react) workflow that generated this translation for more details.

Feel free to review and suggest any improvements to the translation.