### PR TITLE
Translate `react-conf-2021-recap.md` to pt-BR

### DIFF
--- a/src/content/blog/2021/12/17/react-conf-2021-recap.md
+++ b/src/content/blog/2021/12/17/react-conf-2021-recap.md
@@ -1,160 +1,160 @@
 ---
-title: "React Conf 2021 Recap"
-author: Jesslyn Tannady and Rick Hanlon
+title: "Resumo da React Conf 2021"
+author: Jesslyn Tannady e Rick Hanlon
 date: 2021/12/17
-description: Last week we hosted our 6th React Conf. In previous years, we've used the React Conf stage to deliver industry changing announcements such as React Native and React Hooks. This year, we shared our multi-platform vision for React, starting with the release of React 18 and gradual adoption of concurrent features.
+description: Na semana passada, sediamos nossa 6ª React Conf. Em anos anteriores, usamos o palco da React Conf para fazer anúncios que mudaram a indústria, como React Native e React Hooks. Este ano, compartilhamos nossa visão multiplataforma para React, começando com o lançamento do React 18 e a adoção gradual de recursos concorrentes.
 ---
 
-December 17, 2021 by [Jesslyn Tannady](https://twitter.com/jtannady) and [Rick Hanlon](https://twitter.com/rickhanlonii)
+17 de dezembro de 2021 por [Jesslyn Tannady](https://twitter.com/jtannady) e [Rick Hanlon](https://twitter.com/rickhanlonii)
 
 ---
 
 <Intro>
 
-Last week we hosted our 6th React Conf. In previous years, we've used the React Conf stage to deliver industry changing announcements such as [_React Native_](https://engineering.fb.com/2015/03/26/android/react-native-bringing-modern-web-techniques-to-mobile/) and [_React Hooks_](https://reactjs.org/docs/hooks-intro.html). This year, we shared our multi-platform vision for React, starting with the release of React 18 and gradual adoption of concurrent features.
+Na semana passada, sediamos nossa 6ª React Conf. Em anos anteriores, usamos o palco da React Conf para fazer anúncios que mudaram a indústria, como [_React Native_](https://engineering.fb.com/2015/03/26/android/react-native-bringing-modern-web-techniques-to-mobile/) e [_React Hooks_](https://reactjs.org/docs/hooks-intro.html). Este ano, compartilhamos nossa visão multiplataforma para React, começando com o lançamento do React 18 e a adoção gradual de recursos concorrentes.
 
 </Intro>
 
 ---
 
-This was the first time React Conf was hosted online, and it was streamed for free, translated to 8 different languages. Participants from all over the world joined our conference Discord and the replay event for accessibility in all timezones. Over 50,000 people registered, with over 60,000 views of 19 talks, and 5,000 participants in Discord across both events.
+Esta foi a primeira vez que a React Conf foi hospedada online e foi transmitida gratuitamente, traduzida para 8 idiomas diferentes. Participantes de todo o mundo entraram em nosso Discord da conferência e no evento de replay para acessibilidade em todos os fusos horários. Mais de 50.000 pessoas se registraram, com mais de 60.000 visualizações de 19 palestras e 5.000 participantes no Discord nos dois eventos.
 
-All the talks are [available to stream online](https://www.youtube.com/watch?v=FZ0cG47msEk&list=PLNG_1j3cPCaZZ7etkzWA7JfdmKWT0pMsa).
+Todas as palestras estão [disponíveis para transmissão online](https://www.youtube.com/watch?v=FZ0cG47msEk&list=PLNG_1j3cPCaZZ7etkzWA7JfdmKWT0pMsa).
 
-Here’s a summary of what was shared on stage:
+Aqui está um resumo do que foi compartilhado no palco:
 
-## React 18 and concurrent features {/*react-18-and-concurrent-features*/}
+## React 18 e recursos concorrentes {/*react-18-and-concurrent-features*/}
 
-In the keynote, we shared our vision for the future of React starting with React 18.
+Na palestra principal, compartilhamos nossa visão para o futuro do React, começando com o React 18.
 
-React 18 adds the long-awaited concurrent renderer and updates to Suspense without any major breaking changes. Apps can upgrade to React 18 and begin gradually adopting concurrent features with the amount of effort on par with any other major release.
+React 18 adiciona o tão esperado renderizador concorrente e atualizações para Suspense sem grandes mudanças radicais. Os aplicativos podem atualizar para o React 18 e começar a adotar gradualmente os recursos concorrentes com um esforço semelhante ao de qualquer outra versão principal.
 
-**This means there is no concurrent mode, only concurrent features.**
+**Isso significa que não há modo concorrente, apenas recursos concorrentes.**
 
-In the keynote, we also shared our vision for Suspense, Server Components, new React working groups, and our long-term many-platform vision for React Native.
+Na palestra principal, também compartilhamos nossa visão para Suspense, Server Components, novos grupos de trabalho do React e nossa visão de longo prazo para várias plataformas para React Native.
 
-Watch the full keynote from [Andrew Clark](https://twitter.com/acdlite), [Juan Tejada](https://twitter.com/_jstejada), [Lauren Tan](https://twitter.com/potetotes), and [Rick Hanlon](https://twitter.com/rickhanlonii) here:
+Assista à palestra principal completa de [Andrew Clark](https://twitter.com/acdlite), [Juan Tejada](https://twitter.com/_jstejada), [Lauren Tan](https://twitter.com/potetotes) e [Rick Hanlon](https://twitter.com/rickhanlonii) aqui:
 
 <YouTubeIframe src="https://www.youtube.com/embed/FZ0cG47msEk" />
 
-## React 18 for Application Developers {/*react-18-for-application-developers*/}
+## React 18 para desenvolvedores de aplicativos {/*react-18-for-application-developers*/}
 
-In the keynote, we also announced that the React 18 RC is available to try now. Pending further feedback, this is the exact version of React that we will publish to stable early next year.
+Na palestra principal, também anunciamos que o React 18 RC está disponível para experimentar agora. Aguardando mais comentários, esta é a versão exata do React que publicaremos estável no início do próximo ano.
 
-To try the React 18 RC, upgrade your dependencies:
+Para experimentar o React 18 RC, atualize suas dependências:
 
 ```bash
 npm install react@rc react-dom@rc
 ```
 
-and switch to the new `createRoot` API:
+e mude para a nova API `createRoot`:
 
 ```js
-// before
+// antes
 const container = document.getElementById('root');
 ReactDOM.render(<App />, container);
 
-// after
+// depois
 const container = document.getElementById('root');
 const root = ReactDOM.createRoot(container);
 root.render(<App/>);
 ```
 
-For a demo of upgrading to React 18, see [Shruti Kapoor](https://twitter.com/shrutikapoor08)’s talk here:
+Para uma demonstração da atualização para React 18, consulte a palestra de [Shruti Kapoor](https://twitter.com/shrutikapoor08) aqui:
 
 <YouTubeIframe src="https://www.youtube.com/embed/ytudH8je5ko" />
 
-## Streaming Server Rendering with Suspense {/*streaming-server-rendering-with-suspense*/}
+## Renderização de servidor de streaming com Suspense {/*streaming-server-rendering-with-suspense*/}
 
-React 18 also includes improvements to server-side rendering performance using Suspense.
+React 18 também inclui melhorias no desempenho da renderização do lado do servidor usando Suspense.
 
-Streaming server rendering lets you generate HTML from React components on the server, and stream that HTML to your users. In React 18, you can use `Suspense` to break down your app into smaller independent units which can be streamed independently of each other without blocking the rest of the app. This means users will see your content sooner and be able to start interacting with it much faster.
+A renderização de streaming do lado do servidor permite gerar HTML de componentes React no servidor e transmitir esse HTML para seus usuários. No React 18, você pode usar `Suspense` para dividir seu aplicativo em unidades menores e independentes, que podem ser transmitidas independentemente umas das outras, sem bloquear o restante do aplicativo. Isso significa que os usuários verão seu conteúdo mais cedo e poderão começar a interagir com ele muito mais rápido.
 
-For a deep dive, see [Shaundai Person](https://twitter.com/shaundai)’s talk here:
+Para um mergulho profundo, consulte a palestra de [Shaundai Person](https://twitter.com/shaundai) aqui:
 
 <YouTubeIframe src="https://www.youtube.com/embed/pj5N-Khihgc" />
 
-## The first React working group {/*the-first-react-working-group*/}
+## O primeiro grupo de trabalho do React {/*the-first-react-working-group*/}
 
-For React 18, we created our first Working Group to collaborate with a panel of experts, developers, library maintainers, and educators. Together we worked to create our gradual adoption strategy and refine new APIs such as `useId`, `useSyncExternalStore`, and `useInsertionEffect`.
+Para o React 18, criamos nosso primeiro Grupo de Trabalho para colaborar com um painel de especialistas, desenvolvedores, mantenedores de bibliotecas e educadores. Juntos, trabalhamos para criar nossa estratégia de adoção gradual e refinar novas APIs, como `useId`, `useSyncExternalStore` e `useInsertionEffect`.
 
-For an overview of this work, see [Aakansha' Doshi](https://twitter.com/aakansha1216)'s talk:
+Para uma visão geral deste trabalho, consulte a palestra de [Aakansha' Doshi](https://twitter.com/aakansha1216):
 
 <YouTubeIframe src="https://www.youtube.com/embed/qn7gRClrC9U" />
 
 ## React Developer Tooling {/*react-developer-tooling*/}
 
-To support the new features in this release, we also announced the newly formed React DevTools team and a new Timeline Profiler to help developers debug their React apps.
+Para dar suporte aos novos recursos desta versão, também anunciamos a recém-formada equipe React DevTools e um novo Timeline Profiler para ajudar os desenvolvedores a depurar seus aplicativos React.
 
-For more information and a demo of new DevTools features, see [Brian Vaughn](https://twitter.com/brian_d_vaughn)’s talk:
+Para obter mais informações e uma demonstração dos novos recursos do DevTools, consulte a palestra de [Brian Vaughn](https://twitter.com/brian_d_vaughn):
 
 <YouTubeIframe src="https://www.youtube.com/embed/oxDfrke8rZg" />
 
-## React without memo {/*react-without-memo*/}
+## React sem memo {/*react-without-memo*/}
 
-Looking further into the future, [Xuan Huang (黄玄)](https://twitter.com/Huxpro) shared an update from our React Labs research into an auto-memoizing compiler. Check out this talk for more information and a demo of the compiler prototype:
+Olhando mais para o futuro, [Xuan Huang (黄玄)](https://twitter.com/Huxpro) compartilhou uma atualização de nossa pesquisa do React Labs em um compilador de memorização automática. Confira esta palestra para obter mais informações e uma demonstração do protótipo do compilador:
 
 <YouTubeIframe src="https://www.youtube.com/embed/lGEMwh32soc" />
 
-## React docs keynote {/*react-docs-keynote*/}
+## Palestra principal sobre a documentação do React {/*react-docs-keynote*/}
 
-[Rachel Nabors](https://twitter.com/rachelnabors) kicked off a section of talks about learning and designing with React with a keynote about our investment in React's new docs ([now shipped as react.dev](/blog/2023/03/16/introducing-react-dev)):
+[Rachel Nabors](https://twitter.com/rachelnabors) deu início a uma seção de palestras sobre aprendizado e design com React com uma palestra principal sobre nosso investimento na nova documentação do React ([agora lançada como react.dev](/blog/2023/03/16/introducing-react-dev)):
 
 <YouTubeIframe src="https://www.youtube.com/embed/mneDaMYOKP8" />
 
-## And more... {/*and-more*/}
+## E mais... {/*and-more*/}
 
-**We also heard talks on learning and designing with React:**
+**Também ouvimos palestras sobre aprendizado e design com React:**
 
-* Debbie O'Brien: [Things I learnt from the new React docs](https://youtu.be/-7odLW_hG7s).
-* Sarah Rainsberger: [Learning in the Browser](https://youtu.be/5X-WEQflCL0).
-* Linton Ye: [The ROI of Designing with React](https://youtu.be/7cPWmID5XAk).
-* Delba de Oliveira: [Interactive playgrounds with React](https://youtu.be/zL8cz2W0z34).
+* Debbie O'Brien: [Coisas que aprendi com a nova documentação do React](https://youtu.be/-7odLW_hG7s).
+* Sarah Rainsberger: [Aprendendo no navegador](https://youtu.be/5X-WEQflCL0).
+* Linton Ye: [O ROI do design com React](https://youtu.be/7cPWmID5XAk).
+* Delba de Oliveira: [Playgrounds interativos com React](https://youtu.be/zL8cz2W0z34).
 
-**Talks from the Relay, React Native, and PyTorch teams:**
+**Palestras das equipes Relay, React Native e PyTorch:**
 
-* Robert Balicki: [Re-introducing Relay](https://youtu.be/lhVGdErZuN4).
-* Eric Rozell and Steven Moyes: [React Native Desktop](https://youtu.be/9L4FFrvwJwY).
-* Roman Rädle: [On-device Machine Learning for React Native](https://youtu.be/NLj73vrc2I8)
+* Robert Balicki: [Reapresentando o Relay](https://youtu.be/lhVGdErZuN4).
+* Eric Rozell e Steven Moyes: [React Native Desktop](https://youtu.be/9L4FFrvwJwY).
+* Roman Rädle: [Machine Learning on-device for React Native](https://youtu.be/NLj73vrc2I8)
 
-**And talks from the community on accessibility, tooling, and Server Components:**
+**E palestras da comunidade sobre acessibilidade, ferramentas e Server Components:**
 
-* Daishi Kato: [React 18 for External Store Libraries](https://youtu.be/oPfSC5bQPR8).
-* Diego Haz: [Building Accessible Components in React 18](https://youtu.be/dcm8fjBfro8).
-* Tafu Nakazaki: [Accessible Japanese Form Components with React](https://youtu.be/S4a0QlsH0pU).
-* Lyle Troxell: [UI tools for artists](https://youtu.be/b3l4WxipFsE).
+* Daishi Kato: [React 18 para Bibliotecas de Armazenamento Externo](https://youtu.be/oPfSC5bQPR8).
+* Diego Haz: [Criando Componentes Acessíveis no React 18](https://youtu.be/dcm8fjBfro8).
+* Tafu Nakazaki: [Componentes de formulário japoneses acessíveis com React](https://youtu.be/S4a0QlsH0pU).
+* Lyle Troxell: [Ferramentas de UI para artistas](https://youtu.be/b3l4WxipFsE).
 * Helen Lin: [Hydrogen + React 18](https://youtu.be/HS6vIYkSNks).
 
-## Thank you {/*thank-you*/}
+## Obrigado {/*thank-you*/}
 
-This was our first year planning a conference ourselves, and we have a lot of people to thank.
+Este foi nosso primeiro ano planejando uma conferência nós mesmos, e temos muitas pessoas para agradecer.
 
-First, thanks to all of our speakers [Aakansha Doshi](https://twitter.com/aakansha1216), [Andrew Clark](https://twitter.com/acdlite), [Brian Vaughn](https://twitter.com/brian_d_vaughn), [Daishi Kato](https://twitter.com/dai_shi), [Debbie O'Brien](https://twitter.com/debs_obrien), [Delba de Oliveira](https://twitter.com/delba_oliveira), [Diego Haz](https://twitter.com/diegohaz), [Eric Rozell](https://twitter.com/EricRozell), [Helen Lin](https://twitter.com/wizardlyhel), [Juan Tejada](https://twitter.com/_jstejada), [Lauren Tan](https://twitter.com/potetotes), [Linton Ye](https://twitter.com/lintonye), [Lyle Troxell](https://twitter.com/lyle), [Rachel Nabors](https://twitter.com/rachelnabors), [Rick Hanlon](https://twitter.com/rickhanlonii), [Robert Balicki](https://twitter.com/StatisticsFTW), [Roman Rädle](https://twitter.com/raedle), [Sarah Rainsberger](https://twitter.com/sarah11918), [Shaundai Person](https://twitter.com/shaundai), [Shruti Kapoor](https://twitter.com/shrutikapoor08), [Steven Moyes](https://twitter.com/moyessa), [Tafu Nakazaki](https://twitter.com/hawaiiman0), and  [Xuan Huang (黄玄)](https://twitter.com/Huxpro).
+Primeiro, obrigado a todos os nossos palestrantes [Aakansha Doshi](https://twitter.com/aakansha1216), [Andrew Clark](https://twitter.com/acdlite), [Brian Vaughn](https://twitter.com/brian_d_vaughn), [Daishi Kato](https://twitter.com/dai_shi), [Debbie O'Brien](https://twitter.com/debs_obrien), [Delba de Oliveira](https://twitter.com/delba_oliveira), [Diego Haz](https://twitter.com/diegohaz), [Eric Rozell](https://twitter.com/EricRozell), [Helen Lin](https://twitter.com/wizardlyhel), [Juan Tejada](https://twitter.com/_jstejada), [Lauren Tan](https://twitter.com/potetotes), [Linton Ye](https://twitter.com/lintonye), [Lyle Troxell](https://twitter.com/lyle), [Rachel Nabors](https://twitter.com/rachelnabors), [Rick Hanlon](https://twitter.com/rickhanlonii), [Robert Balicki](https://twitter.com/StatisticsFTW), [Roman Rädle](https://twitter.com/raedle), [Sarah Rainsberger](https://twitter.com/sarah11918), [Shaundai Person](https://twitter.com/shaundai), [Shruti Kapoor](https://twitter.com/shrutikapoor08), [Steven Moyes](https://twitter.com/moyessa), [Tafu Nakazaki](https://twitter.com/hawaiiman0) e [Xuan Huang (黄玄)](https://twitter.com/Huxpro).
 
-Thanks to everyone who helped provide feedback on talks including [Andrew Clark](https://twitter.com/acdlite), [Dan Abramov](https://bsky.app/profile/danabra.mov), [Dave McCabe](https://twitter.com/mcc_abe), [Eli White](https://twitter.com/Eli_White), [Joe Savona](https://twitter.com/en_JS),  [Lauren Tan](https://twitter.com/potetotes), [Rachel Nabors](https://twitter.com/rachelnabors), and [Tim Yung](https://twitter.com/yungsters).
+Obrigado a todos que ajudaram a fornecer feedback sobre as palestras, incluindo [Andrew Clark](https://twitter.com/acdlite), [Dan Abramov](https://bsky.app/profile/danabra.mov), [Dave McCabe](https://twitter.com/mcc_abe), [Eli White](https://twitter.com/Eli_White), [Joe Savona](https://twitter.com/en_JS), [Lauren Tan](https://twitter.com/potetotes), [Rachel Nabors](https://twitter.com/rachelnabors) e [Tim Yung](https://twitter.com/yungsters).
 
-Thanks to [Lauren Tan](https://twitter.com/potetotes) for setting up the conference Discord and serving as our Discord admin.
+Obrigado a [Lauren Tan](https://twitter.com/potetotes) por configurar o Discord da conferência e atuar como nosso administrador do Discord.
 
-Thanks to [Seth Webster](https://twitter.com/sethwebster) for feedback on overall direction and making sure we were focused on diversity and inclusion.
+Obrigado a [Seth Webster](https://twitter.com/sethwebster) por feedback sobre a direção geral e garantir que estávamos focados na diversidade e inclusão.
 
-Thanks to [Rachel Nabors](https://twitter.com/rachelnabors) for spearheading our moderation effort, and [Aisha Blake](https://twitter.com/AishaBlake) for creating our moderation guide, leading our moderation team, training the translators and moderators, and helping to moderate both events.
+Obrigado a [Rachel Nabors](https://twitter.com/rachelnabors) por liderar nosso esforço de moderação e [Aisha Blake](https://twitter.com/AishaBlake) por criar nosso guia de moderação, liderar nossa equipe de moderação, treinar os tradutores e moderadores e ajudar a moderar ambos os eventos.
 
-Thanks to our moderators [Jesslyn Tannady](https://twitter.com/jtannady), [Suzie Grange](https://twitter.com/missuze), [Becca Bailey](https://twitter.com/beccaliz), [Luna Wei](https://twitter.com/lunaleaps), [Joe Previte](https://twitter.com/jsjoeio), [Nicola Corti](https://twitter.com/Cortinico), [Gijs Weterings](https://twitter.com/gweterings), [Claudio Procida](https://twitter.com/claudiopro), Julia Neumann, Mengdi Chen, Jean Zhang, Ricky Li, and [Xuan Huang (黄玄)](https://twitter.com/Huxpro).
+Obrigado aos nossos moderadores [Jesslyn Tannady](https://twitter.com/jtannady), [Suzie Grange](https://twitter.com/missuze), [Becca Bailey](https://twitter.com/beccaliz), [Luna Wei](https://twitter.com/lunaleaps), [Joe Previte](https://twitter.com/jsjoeio), [Nicola Corti](https://twitter.com/Cortinico), [Gijs Weterings](https://twitter.com/gweterings), [Claudio Procida](https://twitter.com/claudiopro), Julia Neumann, Mengdi Chen, Jean Zhang, Ricky Li e [Xuan Huang (黄玄)](https://twitter.com/Huxpro).
 
-Thanks to [Manjula Dube](https://twitter.com/manjula_dube), [Sahil Mhapsekar](https://twitter.com/apheri0), and Vihang Patel from [React India](https://www.reactindia.io/), and [Jasmine Xie](https://twitter.com/jasmine_xby), [QiChang Li](https://twitter.com/QCL15), and [YanLun Li](https://twitter.com/anneincoding) from [React China](https://twitter.com/ReactChina) for helping moderate our replay event and keep it engaging for the community.
+Obrigado a [Manjula Dube](https://twitter.com/manjula_dube), [Sahil Mhapsekar](https://twitter.com/apheri0) e Vihang Patel do [React India](https://www.reactindia.io/) e [Jasmine Xie](https://twitter.com/jasmine_xby), [QiChang Li](https://twitter.com/QCL15) e [YanLun Li](https://twitter.com/anneincoding) do [React China](https://twitter.com/ReactChina) por ajudar a moderar nosso evento de replay e mantê-lo envolvente para a comunidade.
 
-Thanks to Vercel for publishing their [Virtual Event Starter Kit](https://vercel.com/virtual-event-starter-kit), which the conference website was built on, and to [Lee Robinson](https://twitter.com/leeerob) and [Delba de Oliveira](https://twitter.com/delba_oliveira) for sharing their experience running Next.js Conf.
+Obrigado ao Vercel por publicar seu [Kit inicial de evento virtual](https://vercel.com/virtual-event-starter-kit), no qual o site da conferência foi construído, e a [Lee Robinson](https://twitter.com/leeerob) e [Delba de Oliveira](https://twitter.com/delba_oliveira) por compartilhar sua experiência de execução do Next.js Conf.
 
-Thanks to [Leah Silber](https://twitter.com/wifelette) for sharing her experience running conferences, learnings from running [RustConf](https://rustconf.com/), and for her book [Event Driven](https://leanpub.com/eventdriven/) and the advice it contains for running conferences.
+Obrigado a [Leah Silber](https://twitter.com/wifelette) por compartilhar sua experiência de organização de conferências, aprendizado de execução do [RustConf](https://rustconf.com/) e por seu livro [Event Driven](https://leanpub.com/eventdriven/) e os conselhos que ele contém para a organização de conferências.
 
-Thanks to [Kevin Lewis](https://twitter.com/_phzn) and [Rachel Nabors](https://twitter.com/rachelnabors) for sharing their experience running Women of React Conf.
+Obrigado a [Kevin Lewis](https://twitter.com/_phzn) e [Rachel Nabors](https://twitter.com/rachelnabors) por compartilhar sua experiência de execução do Women of React Conf.
 
-Thanks to [Aakansha Doshi](https://twitter.com/aakansha1216), [Laurie Barth](https://twitter.com/laurieontech), [Michael Chan](https://twitter.com/chantastic), and [Shaundai Person](https://twitter.com/shaundai) for their advice and ideas throughout planning.
+Obrigado a [Aakansha Doshi](https://twitter.com/aakansha1216), [Laurie Barth](https://twitter.com/laurieontech), [Michael Chan](https://twitter.com/chantastic) e [Shaundai Person](https://twitter.com/shaundai) por seus conselhos e ideias durante o planejamento.
 
-Thanks to [Dan Lebowitz](https://twitter.com/lebo) for help designing and building the conference website and tickets.
+Obrigado a [Dan Lebowitz](https://twitter.com/lebo) pela ajuda no projeto e construção do site da conferência e ingressos.
 
-Thanks to Laura Podolak Waddell, Desmond Osei-Acheampong, Mark Rossi, Josh Toberman and others on the Facebook Video Productions team for recording the videos for the Keynote and Meta employee talks.
+Obrigado a Laura Podolak Waddell, Desmond Osei-Acheampong, Mark Rossi, Josh Toberman e outros da equipe de Produções de Vídeo do Facebook por gravar os vídeos da Palestra Principal e das palestras dos funcionários da Meta.
 
-Thanks to our partner HitPlay for helping to organize the conference, editing all the videos in the stream, translating all the talks, and moderating the Discord in multiple languages.
+Obrigado ao nosso parceiro HitPlay por ajudar a organizar a conferência, editar todos os vídeos na transmissão, traduzir todas as palestras e moderar o Discord em vários idiomas.
 
-Finally, thanks to all of our participants for making this a great React Conf!
+Finalmente, obrigado a todos os nossos participantes por fazer desta uma ótima React Conf!


### PR DESCRIPTION
This pull request contains a translation of the referenced page into Portuguese (pt-BR). The translation was generated using LLMs _(Open Router API :: model `google/gemini-2.0-flash-lite-001`)_.

Refer to the [source repository](https://github.com/NivaldoFarias/translate-react) workflow that generated this translation for more details.

Feel free to review and suggest any improvements to the translation.