### PR TITLE
Translate `introducing-react-dev.md` to pt-BR

### DIFF
--- a/src/content/blog/2023/03/16/introducing-react-dev.md
+++ b/src/content/blog/2023/03/16/introducing-react-dev.md
@@ -19,7 +19,7 @@ Hoje estamos muito felizes em lançar [react.dev](https://react.dev), a nova cas
 
 ## tl;dr {/*tldr*/}
 
-* O novo site do React ([react.dev](https://react.dev)) ensina o React moderno com componentes de função e Hooks.
+* O novo site do React ([react.dev](https://react.dev)) ensina React moderno com *function components* e *Hooks*.
 * Incluímos diagramas, ilustrações, desafios, e mais de 600 novos exemplos interativos.
 * O site anterior de documentação do React foi movido para [legacy.reactjs.org](https://pt-br.legacy.reactjs.org).
 
@@ -31,30 +31,30 @@ Para celebrar o lançamento da nova documentação e, mais importante ainda, par
 
 A antiga documentação do React agora está arquivada em [legacy.reactjs.org](https://pt-br.legacy.reactjs.org). Todos os links existentes para o conteúdo antigo serão redirecionados automaticamente para lá, a fim de evitar "quebrar a web", mas o site legado não receberá mais muitas atualizações.
 
-Acredite ou não, o React vai fazer dez anos de idade em breve. Em anos de JavaScript, é como se fosse um século inteiro! Atualizamos a [página inicial do React](https://react.dev) para refletir o porquê achamos que o React é uma ótima maneira de criar interfaces de usuário atualmente e atualizamos os guias de introdução para mencionar com mais destaque os frameworks modernos baseados em React.
+Acredite ou não, o React vai fazer dez anos de idade em breve. Em anos de JavaScript, é como se fosse um século inteiro! Atualizamos a [página inicial do React](https://react.dev) para refletir o porquê achamos que o React é uma ótima maneira de criar interfaces de usuário atualmente e atualizamos os guias de introdução para mencionar com mais destaque os *frameworks* modernos baseados em React.
 
 Se ainda não viu a nova página inicial, veja!
 
-## Apostando tudo no React moderno com Hooks {/*going-all-in-on-modern-react-with-hooks*/}
+## Apostando tudo no React moderno com *Hooks* {/*going-all-in-on-modern-react-with-hooks*/}
 
-Quando lançamos o React Hooks em 2018, os documentos do Hooks assumiram que o leitor estava familiarizado com componentes de classe. Isso ajudou a comunidade a adotar Hooks muito rapidamente, mas depois de um tempo os documentos antigos falharam em servir os novos leitores. Novos leitores tiveram que aprender React duas vezes: uma vez com componentes de classe e outra vez com Hooks.
+Quando lançamos o React *Hooks* em 2018, os documentos dos *Hooks* assumiram que o leitor estava familiarizado com *class components*. Isso ajudou a comunidade a adotar *Hooks* muito rapidamente, mas depois de um tempo os documentos antigos falharam em servir os novos leitores. Novos leitores tiveram que aprender React duas vezes: uma vez com *class components* e outra vez com *Hooks*.
 
-**A nova documentação ensina React com Hooks desde o início.** A documentação está dividida em duas seções principais:
+**A nova documentação ensina React com *Hooks* desde o início.** A documentação está dividida em duas seções principais:
 
-* **[Aprenda React](/learn)** é um curso individualizado que ensina React do zero.
-* **[Referências de API](/reference)** fornece os detalhes e exemplos de uso para cada API React.
+*   **[Aprenda React](/learn)** é um curso individualizado que ensina React do zero.
+*   **[Referências de API](/reference)** fornece os detalhes e exemplos de uso para cada API React.
 
 Vamos ver mais detalhadamente o que pode encontrar em cada seção.
 
 <Note>
 
-Ainda existem alguns casos raros de uso de componentes de classe que ainda não possuem um equivalente baseado em Hook. Os componentes de classe continuam a ser suportados, e estão documentados na seção [Legacy API](/reference/react/legacy) do novo site.
+Ainda existem alguns casos raros de uso de *class components* que ainda não possuem um equivalente baseado em *Hook*. Os *class components* continuam a ser suportados, e estão documentados na seção [Legacy API](/reference/react/legacy) do novo site.
 
 </Note>
 
 ## Início rápido {/*quick-start*/}
 
-A seção Aprender começa com a página [Início Rápido](/learn). É um pequeno tour introdutório do React. Ele introduz a sintaxe para conceitos como componentes, props (propriedades) e state (estado), mas não entra em muitos detalhes sobre como usá-los.
+A seção Aprender começa com a página [Início Rápido](/learn). É um pequeno tour introdutório do React. Ele introduz a sintaxe para conceitos como *components, props* (propriedades) e *state* (estado), mas não entra em muitos detalhes sobre como usá-los.
 
 Se você gosta de aprender fazendo, recomendamos que confira o [Tutorial: Jogo da Velha](/learn/tutorial-tic-tac-toe) a seguir. Ele o orienta na construção de um pequeno jogo com React, enquanto ensina as habilidades que você usará todos os dias. Aqui está o que você vai construir:
 
@@ -225,11 +225,11 @@ body {
 
 </Sandpack>
 
-Nós também gostaríamos de destacar [Pensando em React](/learn/thinking-in-react)—esse é o tutorial que fez o React "clicar" para muitos de nós. **Atualizamos esses dois tutoriais clássicos para usar componentes de função e Hooks,** para que fiquem como novos.
+Nós também gostaríamos de destacar [Pensando em React](/learn/thinking-in-react)—esse é o tutorial que fez o React "clicar" para muitos de nós. **Atualizamos esses dois tutoriais clássicos para usar *function components* e *Hooks*,** para que fiquem como novos.
 
 <Note>
 
-O exemplo acima é uma *sandbox*. Adicionamos muitas sandboxes—mais de 600!—em todo o site. Você pode editar qualquer sandbox, ou pressionar "Fork" no canto superior direito para abri-la em uma aba separada. As sandboxes permitem que você brinque rapidamente com as APIs do React, explore suas ideias e verifique seu entendimento.
+O exemplo acima é uma *sandbox*. Adicionamos muitas *sandboxes*—mais de 600!—em todo o site. Você pode editar qualquer *sandbox*, ou pressionar "Fork" no canto superior direito para abri-la em uma aba separada. As *sandboxes* permitem que você brinque rapidamente com as APIs do React, explore suas ideias e verifique seu entendimento.
 
 </Note>
 
@@ -239,13 +239,13 @@ Gostaríamos que todos no mundo tivessem a mesma oportunidade de aprender React 
 
 É por isso que a seção Aprenda está organizada como um curso individualizado dividido em capítulos. Os dois primeiros capítulos descrevem os fundamentos do React. Se você é novo no React, ou quer refrescar sua memória, comece aqui:
 
-- **[Descrevendo a IU](/learn/describing-the-ui)** ensina a exibir informações com componentes.
-- **[Adicionando Interatividade](/learn/adding-interactivity)** ensina como atualizar a tela em resposta à entrada do usuário.
+-   **[Descrevendo a IU](/learn/describing-the-ui)** ensina a exibir informações com componentes.
+-   **[Adicionando Interatividade](/learn/adding-interactivity)** ensina como atualizar a tela em resposta à entrada do usuário.
 
 Os próximos dois capítulos são mais avançados e fornecerão uma compreensão mais profunda das partes mais complicadas:
 
-- **[Gerenciando o Estado](/learn/managing-state)** ensina como organizar sua lógica à medida que seu aplicativo se torna mais complexo.
-- **[Saídas de Emergência](/learn/escape-hatches)** ensina como você pode 'sair do escopo' do React e quando isso faz mais sentido.
+-   **[Gerenciando o Estado](/learn/managing-state)** ensina como organizar sua lógica à medida que seu aplicativo se torna mais complexo.
+-   **[Saídas de Emergência](/learn/escape-hatches)** ensina como você pode 'sair do escopo' do React e quando isso faz mais sentido.
 
 Cada capítulo consiste em várias páginas relacionadas. A maioria dessas páginas ensina uma habilidade específica ou uma técnica—por exemplo, [Escrevendo Tags com JSX](/learn/writing-markup-with-jsx), [Atualizando Objetos no State](/learn/updating-objects-in-state), ou [Compartilhando State Entre Componentes](/learn/sharing-state-between-components). Algumas das páginas focam na explicação de uma idéia—como [Renderizar e Confirmar](/learn/render-and-commit), ou [State como uma Foto Instantânea](/learn/state-as-a-snapshot). E há alguns, como [Talvez você não precise de um Effect](/learn/you-might-not-need-an-effect), que compartilham nossas sugestões com base no que aprendemos ao longo desses anos.
 
@@ -259,9 +259,9 @@ Você não precisa resolvê-los agora! A menos que você *realmente* queira.
 
 <Challenges noTitle={true}>
 
-#### Mostre um ícone para itens incompletos com `? :` {/*show-an-icon-for-incomplete-items-with--*/}
+#### Mostre um ícone para itens incompletos com \`? :\` {/*show-an-icon-for-incomplete-items-with--*/}
 
-Use o operador condicional (`cond ? a : b`) para renderizar um ❌ se `isPacked` não for `true`.
+Use o operador condicional (\`cond ? a : b\`) para renderizar um ❌ se \`isPacked\` não for \`true\`.
 
 <Sandpack>
 
@@ -339,13 +339,13 @@ export default function PackingList() {
 
 </Solution>
 
-#### Mostrar a importância do item com `&&` {/*show-the-item-importance-with-*/}
+#### Mostrar a importância do item com \`&&\` {/*show-the-item-importance-with-*/}
 
-Neste exemplo, cada `Item` recebe uma prop `importance` numérica. Use o operador `&&` para renderizar "_(Relevância: X)_" em itálico, mas apenas para os itens que têm relevância diferente de zero. Sua lista de itens deve ficar assim:
+Neste exemplo, cada \`Item\` recebe uma prop \`importance\` numérica. Use o operador \`&&\` para renderizar "_\(Relevância: X\)_" em itálico, mas apenas para os itens que têm relevância diferente de zero. Sua lista de itens deve ficar assim:
 
-* Traje espacial _(Relevância: 9)_
-* Capacete com folha dourada
-* Foto de Tam _(Relevância: 6)_
+*   Traje espacial _(Relevância: 9)_
+*   Capacete com folha dourada
+*   Foto de Tam _(Relevância: 6)_
 
 Não se esqueça de adicionar um espaço entre as duas etiquetas!
 
@@ -429,9 +429,9 @@ export default function PackingList() {
 
 </Sandpack>
 
-Observe que você deve escrever `importance > 0 && ...` ao invés de `importance && ...` para que, se `importance` for `0`, `0` não seja renderizado como resultado!
+Observe que você deve escrever \`importance > 0 && ...\` ao invés de \`importance && ...\` para que, se \`importance\` for \`0\`, \`0\` não seja renderizado como resultado!
 
-Nessa solução, duas condições separadas são usadas para inserir um espaço entre o nome e a etiqueta de relevância. Alternativamente, você pode usar um fragmento com um espaço inicial: `<i>`:  `importance > 0 && <i> ...</i>`.
+Nessa solução, duas condições separadas são usadas para inserir um espaço entre o nome e a etiqueta de relevância. Alternativamente, você pode usar um fragmento com um espaço inicial: \`<i>\`:  \`importance > 0 && <i> ...</i>\`.
 
 </Solution>
 
@@ -445,7 +445,7 @@ Quando não conseguimos descobrir como explicar algo apenas com código e palavr
 
 <Diagram name="preserving_state_diff_same_pt1" height={350} width={794} alt="Diagrama com três seções, com uma seta fazendo a transição entre cada seção. A primeira seção contém um componente React chamado 'div' com um único filho chamado 'section', que tem um único filho chamado 'Counter' contendo uma bolha de estado chamada 'count' com valor 3. A seção do meio tem o mesmo pai 'div', mas os componentes filhos foram excluídos, indicados por uma imagem amarela de 'prova'. A terceira seção tem o mesmo pai 'div' novamente, agora com um novo filho rotulado 'div', destacado em amarelo, também com um novo filho rotulado 'Counter' contendo uma bolha de estado rotulada 'count' com valor 0, todos destacados em amarelo.">
 
-Quando `section` muda para `div`, a `section` é apagada e a nova `div` é adicionada
+Quando \`section\` muda para \`div\`, a \`section\` é apagada e a nova \`div\` é adicionada
 
 </Diagram>
 
@@ -459,11 +459,11 @@ Confirmamos com os desenvolvedores de navegadores que esta representação é 10
 
 Na [API de Referência](/reference/react), cada API React tem agora uma página dedicada. Isso inclui todos os tipos de APIs:
 
-- Hooks incorporados como [`useState`](/reference/react/useState).
-- Componentes incorporados como [`<Suspense>`](/reference/react/Suspense).
-- Componentes do navegador incorporados como [`<input>`](/reference/react-dom/components/input).
-- APIs orientadas para frameworks como[`renderToPipeableStream`](/reference/react-dom/server/renderToReadableStream).
-- Outras APIs do React como [`memo`](/reference/react/memo).
+-   *Hooks* incorporados como \[`useState`](/reference/react/useState).
+-   Componentes incorporados como \[`<Suspense>`](/reference/react/Suspense).
+-   Componentes do navegador incorporados como \[`<input>`](/reference/react-dom/components/input).
+-   APIs orientadas para *frameworks* como\[`renderToPipeableStream`](/reference/react-dom/server/renderToReadableStream).
+-   Outras APIs do React como \[`memo`](/reference/react/memo).
 
 Você perceberá que cada página de API é dividida em pelo menos dois segmentos: *Referência* e *Uso*.
 
@@ -475,7 +475,7 @@ Você perceberá que cada página de API é dividida em pelo menos dois segmento
 
 #### Contador (número) {/*counter-number*/}
 
-Neste exemplo, a variável state `count` armazena um número. Ao clicar no botão, ele é incrementado.
+Neste exemplo, a variável *state* \`count\` armazena um número. Ao clicar no botão, ele é incrementado.
 
 <Sandpack>
 
@@ -503,7 +503,7 @@ export default function Counter() {
 
 #### Caixa de texto (string) {/*text-field-string*/}
 
-Neste exemplo, a variável state `text` armazena uma string. Quando você digita, `handleChange` lê o valor de entrada mais recente do elemento DOM de entrada do navegador e chama `setText` para atualizar o state. Isso permite que você exiba o `text` atual abaixo.
+Neste exemplo, a variável *state* \`text\` armazena uma *string*. Quando você digita, \`handleChange\` lê o valor de entrada mais recente do elemento DOM de entrada do navegador e chama \`setText\` para atualizar o *state*. Isso permite que você exiba o \`text\` atual abaixo.
 
 <Sandpack>
 
@@ -535,7 +535,7 @@ export default function MyInput() {
 
 #### Caixa de seleção (boolean) {/*checkbox-boolean*/}
 
-Neste exemplo, a variável state `liked` armazena um valor booleano. Quando você clica no input, `setLiked` atualiza a variável state `liked` com base em se a caixa de seleção do navegador está marcada. A variável `liked` é usada para renderizar o texto abaixo da caixa de seleção.
+Neste exemplo, a variável *state* \`liked\` armazena um valor booleano. Quando você clica no *input*, \`setLiked\` atualiza a variável *state* \`liked\` com base em se a caixa de seleção do navegador está marcada. A variável \`liked\` é usada para renderizar o texto abaixo da caixa de seleção.
 
 <Sandpack>
 
@@ -571,7 +571,7 @@ export default function MyCheckbox() {
 
 #### Formulário (duas variáveis) {/*form-two-variables*/}
 
-Você pode declarar mais de uma variável state no mesmo componente. Cada variável state é completamente independente.
+Você pode declarar mais de uma variável *state* no mesmo componente. Cada variável *state* é completamente independente.
 
 <Sandpack>
 
@@ -615,15 +615,15 @@ Esperamos que esta abordagem torne a referência da API útil não só como uma 
 
 E assim termina nosso pequeno tour! Dê uma olhada no novo site, veja o que você gosta ou não gosta e continue enviando feedback em nosso [rastreador de problemas](https://github.com/reactjs/reactjs.org/issues).
 
-Reconhecemos que este projeto demorou muito tempo a ser lançado. Nós queríamos manter um alto nível de qualidade que a comunidade React merece. Enquanto escrevíamos essa documentação e criávamos todos os exemplos, encontramos erros em algumas de nossas próprias explicações, bugs no React e até mesmo lacunas no design do React que agora estamos trabalhando para resolver. Esperamos que a nova documentação nos ajude a manter o próprio React em um nível mais alto no futuro.
+Reconhecemos que este projeto demorou muito tempo a ser lançado. Nós queríamos manter um alto nível de qualidade que a comunidade React merece. Enquanto escrevíamos essa documentação e criávamos todos os exemplos, encontramos erros em algumas de nossas próprias explicações, *bugs* no React e até mesmo lacunas no *design* do React que agora estamos trabalhando para resolver. Esperamos que a nova documentação nos ajude a manter o próprio React em um nível mais alto no futuro.
 
 Ouvimos muitos dos seus pedidos para expandir o conteúdo e a funcionalidade do site, por exemplo:
 
-- Fornecimento de uma versão TypeScript para todos os exemplos;
-- Criar os guias atualizados de desempenho, teste e acessibilidade;
-- Documentar os componentes do React Server independentemente dos frameworks que os suportam;
-- Trabalhar com nossa comunidade internacional para traduzir os novos documentos;
-- Adicionar recursos ausentes ao novo site (por exemplo, RSS para este blog).
+-   Fornecimento de uma versão TypeScript para todos os exemplos;
+-   Criar os guias atualizados de desempenho, teste e acessibilidade;
+-   Documentar os componentes do React Server independentemente dos *frameworks* que os suportam;
+-   Trabalhar com nossa comunidade internacional para traduzir os novos documentos;
+-   Adicionar recursos ausentes ao novo site (por exemplo, RSS para este *blog*).
 
 Agora que o [react.dev](https://react.dev/) foi lançado, seremos capazes de mudar nosso foco de "acompanhar" os recursos educacionais de terceiros sobre o React para adicionar novas informações e melhorar ainda mais nosso novo site.
 
@@ -637,12 +637,12 @@ Na equipe do React, [Rachel Nabors](https://twitter.com/rachelnabors/) liderou o
 
 [Sylwia Vargas](https://twitter.com/SylwiaVargas) reformulou nossos exemplos para ir além de "foo/bar/baz" e gatinhos, e apresentamos cientistas, artistas e cidades de todo o mundo. [Maggie Appleton](https://twitter.com/Mappletons) transformou nossos rabiscos em um sistema de diagrama claro.
 
-Agradecimentos a [David McCabe](https://twitter.com/mcc_abe), [Sophie Alpert](https://twitter.com/sophiebits), [Rick Hanlon](https://twitter.com/rickhanlonii), [Andrew Clark](https://twitter.com/acdlite), e [Matt Carroll](https://twitter.com/mattcarrollcode) por outras contribuições escritas. Também gostaríamos de agradecer a [Natalia Tepluhina](https://twitter.com/n_tepluhina) e [Sebastian Markbåge](https://twitter.com/sebmarkbage) por suas ideias e feedback.
+Agradecimentos a [David McCabe](https://twitter.com/mcc_abe), [Sophie Alpert](https://twitter.com/sophiebits), [Rick Hanlon](https://twitter.com/rickhanlonii), [Andrew Clark](https://twitter.com/acdlite), e [Matt Carroll](https://twitter.com/mattcarrollcode) por outras contribuições escritas. Também gostaríamos de agradecer a [Natalia Tepluhina](https://twitter.com/n_tepluhina) e [Sebastian Markbåge](https://twitter.com/sebmarkbage) por suas ideias e *feedback*.
 
-Obrigado a [Dan Lebowitz](https://twitter.com/lebo) pelo design do site e [Razvan Gradinar](https://dribbble.com/GradinarRazvan) pelo design da sandbox.
+Obrigado a [Dan Lebowitz](https://twitter.com/lebo) pelo *design* do site e [Razvan Gradinar](https://dribbble.com/GradinarRazvan) pelo *design* da *sandbox*.
 
-Na frente de desenvolvimento, obrigado a [Jared Palmer](https://twitter.com/jaredpalmer) pelo desenvolvimento de protótipos. Agradecimentos a [Dane Grant](https://twitter.com/danecando) e [Dustin Goodman](https://twitter.com/dustinsgoodman) de [ThisDotLabs](https://www.thisdot.co/) por seu apoio no desenvolvimento da UI. Agradecimentos a [Ives van Hoorne](https://twitter.com/CompuIves), [Alex Moldovan](https://twitter.com/alexnmoldovan), [Jasper De Moor](https://twitter.com/JasperDeMoor), e [Danilo Woznica](https://twitter.com/danilowoz) de [CodeSandbox](https://codesandbox.io/) por seu trabalho com a integração da sandbox. Agradecimentos a [Rick Hanlon](https://twitter.com/rickhanlonii) para o trabalho de desenvolvimento e design, aprimorando nossas cores e detalhes mais finos. Agradecimentos a [Harish Kumar](https://www.strek.in/) e [Luna Ruan](https://twitter.com/lunaruan) por adicionar novos recursos ao site e ajudar a mantê-lo.
+Na frente de desenvolvimento, obrigado a [Jared Palmer](https://twitter.com/jaredpalmer) pelo desenvolvimento de protótipos. Agradecimentos a [Dane Grant](https://twitter.com/danecando) e [Dustin Goodman](https://twitter.com/dustinsgoodman) de [ThisDotLabs](https://www.thisdot.co/) por seu apoio no desenvolvimento da UI. Agradecimentos a [Ives van Hoorne](https://twitter.com/CompuIves), [Alex Moldovan](https://twitter.com/alexnmoldovan), [Jasper De Moor](https://twitter.com/JasperDeMoor), e [Danilo Woznica](https://twitter.com/danilowoz) de [CodeSandbox](https://codesandbox.io/) por seu trabalho com a integração da *sandbox*. Agradecimentos a [Rick Hanlon](https://twitter.com/rickhanlonii) para o trabalho de desenvolvimento e *design*, aprimorando nossas cores e detalhes mais finos. Agradecimentos a [Harish Kumar](https://www.strek.in/) e [Luna Ruan](https://twitter.com/lunaruan) por adicionar novos recursos ao site e ajudar a mantê-lo.
 
-Agradecemos imensamente às pessoas que ofereceram seu tempo para participar do programa de testes alfa e beta. Seu entusiasmo e seu inestimável feedback nos ajudaram a moldar esses documentos. Um agradecimento especial à nossa beta tester, [Debbie O'Brien](https://twitter.com/debs_obrien), que deu uma palestra sobre sua experiência usando os documentos do React na React Conf 2021.
+Agradecemos imensamente às pessoas que ofereceram seu tempo para participar do programa de testes alfa e beta. Seu entusiasmo e seu inestimável *feedback* nos ajudaram a moldar esses documentos. Um agradecimento especial à nossa *beta tester*, [Debbie O'Brien](https://twitter.com/debs_obrien), que deu uma palestra sobre sua experiência usando os documentos do React na React Conf 2021.
 
 Finalmente, obrigado à comunidade React por ser a inspiração por trás deste esforço. Você é a razão de fazermos isso e esperamos que os novos documentos o ajudem a usar o React para construir qualquer interface de usuário que desejar.


### PR DESCRIPTION
This pull request contains a translation of the referenced page into Portuguese (pt-BR). The translation was generated using LLMs _(Open Router API :: model `google/gemini-2.0-flash-lite-001`)_.

Refer to the [source repository](https://github.com/NivaldoFarias/translate-react) workflow that generated this translation for more details.

Feel free to review and suggest any improvements to the translation.