### PR TITLE
Translate `invalid-aria-prop.md` to pt-BR

### DIFF
--- a/src/content/warnings/invalid-aria-prop.md
+++ b/src/content/warnings/invalid-aria-prop.md
@@ -2,7 +2,7 @@
 title: Aviso de Propriedade ARIA Inválida
 ---
 
-Este aviso será disparado se você tentar renderizar um elemento DOM com uma propriedade `aria-*` que não existe na [especificação] (https://www.w3.org/TR/wai-aria-1.1/#states_and_properties) da Web Accessibility Initiative (WAI) Accessible Rich Internet Application (ARIA).
+Este aviso será disparado se você tentar renderizar um elemento DOM com uma propriedade `aria-*` que não existe na [especificação](https://www.w3.org/TR/wai-aria-1.1/#states_and_properties) da Web Accessibility Initiative (WAI) Accessible Rich Internet Application (ARIA).
 
 1. Se você acredita que está usando uma propriedade válida, verifique a ortografia cuidadosamente. `aria-labelledby` e `aria-activedescendant` são frequentemente escritas de forma incorreta.
 


### PR DESCRIPTION
This pull request contains a translation of the referenced page into Portuguese (pt-BR). The translation was generated using LLMs _(Open Router API :: model `google/gemini-2.0-flash-lite-001`)_.

Refer to the [source repository](https://github.com/NivaldoFarias/translate-react) workflow that generated this translation for more details.

Feel free to review and suggest any improvements to the translation.