### PR TITLE
Translate `react-dom-test-utils.md` to pt-BR

### DIFF
--- a/src/content/warnings/react-dom-test-utils.md
+++ b/src/content/warnings/react-dom-test-utils.md
@@ -28,7 +28,7 @@ A equipe do React recomenda migrar seus testes para [@testing-library/react](htt
 
 ### ReactDOMTestUtils.renderIntoDocument {/*reactdomtestutilsrenderintodocument*/}
 
-O `renderIntoDocument` pode ser substituído por `render` de `@testing-library/react`.
+`renderIntoDocument` pode ser substituído por `render` de `@testing-library/react`.
 
 Antes:
 


### PR DESCRIPTION
This pull request contains a translation of the referenced page into Portuguese (pt-BR). The translation was generated using LLMs _(Open Router API :: model `google/gemini-2.0-flash-lite-001`)_.

Refer to the [source repository](https://github.com/NivaldoFarias/translate-react) workflow that generated this translation for more details.

Feel free to review and suggest any improvements to the translation.