### PR TITLE
Translate `generic.md` to pt

### DIFF
--- a/src/content/errors/generic.md
+++ b/src/content/errors/generic.md
@@ -1,11 +1,11 @@
 <Intro>
 
-In the minified production build of React, we avoid sending down full error messages in order to reduce the number of bytes sent over the wire.
+Na versão de produção minificada do React, evitamos enviar mensagens de erro completas para reduzir o número de bytes enviados pela rede.
 
 </Intro>
 
-We highly recommend using the development build locally when debugging your app since it tracks additional debug info and provides helpful warnings about potential problems in your apps, but if you encounter an exception while using the production build, this page will reassemble the original error message.
+Recomendamos o uso da versão de desenvolvimento localmente ao depurar seu aplicativo, pois ela rastreia informações de depuração adicionais e fornece avisos úteis sobre possíveis problemas em seus aplicativos, mas se você encontrar uma exceção ao usar a versão de produção, esta página remontará a mensagem de erro original.
 
-The full text of the error you just encountered is:
+O texto completo do erro que você acabou de encontrar é:
 
 <ErrorDecoder />


### PR DESCRIPTION
This pull request contains a translation of the referenced page into Portuguese (pt-BR). The translation was generated using LLMs _(Open Router API :: model `google/gemini-2.0-flash-lite-001`)_.

Refer to the [source repository](https://github.com/NivaldoFarias/translate-react) workflow that generated this translation for more details.

Feel free to review and suggest any improvements to the translation.