### PR TITLE
Translate `index.md` to undefined

### DIFF
--- a/src/content/reference/react-dom/hooks/index.md
+++ b/src/content/reference/react-dom/hooks/index.md
@@ -1,20 +1,20 @@
 ---
-title: "Built-in React DOM Hooks"
+title: "Hooks DOM do React embutidos"
 ---
 
 <Intro>
 
-The `react-dom` package contains Hooks that are only supported for web applications (which run in the browser DOM environment). These Hooks are not supported in non-browser environments like iOS, Android, or Windows applications. If you are looking for Hooks that are supported in web browsers *and other environments* see [the React Hooks page](/reference/react). This page lists all the Hooks in the `react-dom` package.
+O pacote `react-dom` contém Hooks que só são suportados para aplicações web (que são executadas no ambiente DOM do navegador). Estes Hooks não são suportados em ambientes que não sejam navegadores, como aplicações iOS, Android ou Windows. Se você estiver procurando por Hooks que são suportados em navegadores web *e outros ambientes*, consulte [a página React Hooks](/reference/react). Esta página lista todos os Hooks no pacote `react-dom`.
 
 </Intro>
 
 ---
 
-## Form Hooks {/*form-hooks*/}
+## Hooks de formulário {/*form-hooks*/}
 
-*Forms* let you create interactive controls for submitting information.  To manage forms in your components, use one of these Hooks:
+*Formulários* permitem criar controles interativos para enviar informações. Para gerenciar formulários em seus componentes, use um destes Hooks:
 
-* [`useFormStatus`](/reference/react-dom/hooks/useFormStatus) allows you to make updates to the UI based on the status of the a form.
+* [`useFormStatus`](/reference/react-dom/hooks/useFormStatus) permite que você faça atualizações na UI com base no status de um formulário.
 
 ```js
 function Form({ action }) {

--- a/src/content/reference/react-dom/index.md
+++ b/src/content/reference/react-dom/index.md
@@ -15,20 +15,20 @@ O pacote `react-dom` contém métodos que são suportados apenas para aplicaçõ
 Essas APIs podem ser importadas em seus componentes. Elas são raramente usadas:
 
 * [`createPortal`](/reference/react-dom/createPortal) permite renderizar componentes filhos em uma parte diferente da árvore DOM.
-* [`flushSync`](/reference/react-dom/flushSync) permite forçar o React a atualizar o estado e atualizar o DOM sincronamente.
+* [`flushSync`](/reference/react-dom/flushSync) permite forçar o React a atualizar o state e atualizar o DOM sincronamente.
 
 ## Resource Preloading APIs {/*resource-preloading-apis*/}
 
-These APIs can be used to make apps faster by pre-loading resources such as scripts, stylesheets, and fonts as soon as you know you need them, for example before navigating to another page where the resources will be used.
+Estas APIs podem ser usadas para tornar apps mais rápidas ao pré-carregar recursos como `scripts`, `stylesheets`, e fontes assim que souber que você precisa delas, por exemplo, antes de navegar para outra página onde os recursos serão usados.
 
-[React-based frameworks](/learn/start-a-new-react-project) frequently handle resource loading for you, so you might not have to call these APIs yourself. Consult your framework's documentation for details.
+[React-based frameworks](/learn/start-a-new-react-project) frequentemente lidam com o carregamento de recursos para você, então você pode não precisar chamar essas APIs sozinho. Consulte a documentação do seu framework para detalhes.
 
-* [`prefetchDNS`](/reference/react-dom/prefetchDNS) lets you prefetch the IP address of a DNS domain name that you expect to connect to.
-* [`preconnect`](/reference/react-dom/preconnect) lets you connect to a server you expect to request resources from, even if you don't know what resources you'll need yet.
-* [`preload`](/reference/react-dom/preload) lets you fetch a stylesheet, font, image, or external script that you expect to use.
-* [`preloadModule`](/reference/react-dom/preloadModule) lets you fetch an ESM module that you expect to use.
-* [`preinit`](/reference/react-dom/preinit) lets you fetch and evaluate an external script or fetch and insert a stylesheet.
-* [`preinitModule`](/reference/react-dom/preinitModule) lets you fetch and evaluate an ESM module.
+* [`prefetchDNS`](/reference/react-dom/prefetchDNS) permite que você pré-busque o endereço IP de um nome de domínio DNS que você espera se conectar.
+* [`preconnect`](/reference/react-dom/preconnect) permite que você se conecte a um servidor do qual você espera solicitar recursos, mesmo que você ainda não saiba quais recursos você vai precisar.
+* [`preload`](/reference/react-dom/preload) permite que você busque uma `stylesheet`, fonte, imagem ou `script` externo que você espera usar.
+* [`preloadModule`](/reference/react-dom/preloadModule) permite que você busque um módulo ESM que você espera usar.
+* [`preinit`](/reference/react-dom/preinit) permite que você busque e avalie um `script` externo ou busque e insira uma `stylesheet`.
+* [`preinitModule`](/reference/react-dom/preinitModule) permite que você busque e avalie um módulo ESM.
 
 ---
 


### PR DESCRIPTION
This pull request contains a translation of the referenced page into Portuguese (pt-BR). The translation was generated using LLMs _(Open Router API :: model `google/gemini-2.0-flash-lite-001`)_.

Refer to the [source repository](https://github.com/NivaldoFarias/translate-react) workflow that generated this translation for more details.

Feel free to review and suggest any improvements to the translation.