### PR TITLE
Translate `preconnect.md` to undefined

### DIFF
--- a/src/content/reference/react-dom/preconnect.md
+++ b/src/content/reference/react-dom/preconnect.md
@@ -4,7 +4,7 @@ title: preconnect
 
 <Intro>
 
-`preconnect` lets you eagerly connect to a server that you expect to load resources from.
+`preconnect` permite que você se conecte imediatamente a um servidor do qual você espera carregar recursos.
 
 ```js
 preconnect("https://example.com");
@@ -16,11 +16,11 @@ preconnect("https://example.com");
 
 ---
 
-## Reference {/*reference*/}
+## Referência {/*reference*/}
 
 ### `preconnect(href)` {/*preconnect*/}
 
-To preconnect to a host, call the `preconnect` function from `react-dom`.
+Para se conectar previamente a um host, chame a função `preconnect` de `react-dom`.
 
 ```js
 import { preconnect } from 'react-dom';
@@ -32,34 +32,33 @@ function AppRoot() {
 
 ```
 
-[See more examples below.](#usage)
+[Veja mais exemplos abaixo.](#usage)
 
-The `preconnect` function provides the browser with a hint that it should open a connection to the given server. If the browser chooses to do so, this can speed up the loading of resources from that server. 
+A função `preconnect` fornece ao navegador uma dica de que ele deve abrir uma conexão com o servidor fornecido. Se o navegador optar por fazê-lo, isso pode acelerar o carregamento de recursos desse servidor.
 
-#### Parameters {/*parameters*/}
+#### Parâmetros {/*parameters*/}
 
-* `href`: a string. The URL of the server you want to connect to.
+* `href`: uma string. A URL do servidor ao qual você deseja se conectar.
 
+#### Retorna {/*returns*/}
 
-#### Returns {/*returns*/}
+`preconnect` não retorna nada.
 
-`preconnect` returns nothing.
+#### Ressalvas {/*caveats*/}
 
-#### Caveats {/*caveats*/}
-
-* Multiple calls to `preconnect` with the same server have the same effect as a single call.
-* In the browser, you can call `preconnect` in any situation: while rendering a component, in an Effect, in an event handler, and so on.
-* In server-side rendering or when rendering Server Components, `preconnect` only has an effect if you call it while rendering a component or in an async context originating from rendering a component. Any other calls will be ignored.
-* If you know the specific resources you'll need, you can call [other functions](/reference/react-dom/#resource-preloading-apis) instead that will start loading the resources right away.
-* There is no benefit to preconnecting to the same server the webpage itself is hosted from because it's already been connected to by the time the hint would be given.
+* Múltiplas chamadas para `preconnect` com o mesmo servidor têm o mesmo efeito de uma única chamada.
+* No navegador, você pode chamar `preconnect` em qualquer situação: ao renderizar um componente, em um Effect, em um manipulador de eventos (event handler), e assim por diante.
+* Na renderização do lado do servidor ou ao renderizar Server Components, `preconnect` só tem efeito se você o chamar enquanto renderiza um componente ou em um contexto assíncrono originário da renderização de um componente. Quaisquer outras chamadas serão ignoradas.
+* Se você souber os recursos específicos de que precisará, poderá chamar [outras funções](/reference/react-dom/#resource-preloading-apis) em vez disso, que iniciarão o carregamento dos recursos imediatamente.
+* Não há nenhum benefício em se conectar previamente ao mesmo servidor em que a própria página da web está hospedada, porque ela já está conectada no momento em que a dica seria dada.
 
 ---
 
-## Usage {/*usage*/}
+## Uso {/*usage*/}
 
-### Preconnecting when rendering {/*preconnecting-when-rendering*/}
+### Preconectando durante a renderização {/*preconnecting-when-rendering*/}
 
-Call `preconnect` when rendering a component if you know that its children will load external resources from that host.
+Chame `preconnect` ao renderizar um componente se você souber que seus filhos carregarão recursos externos desse host.
 
 ```js
 import { preconnect } from 'react-dom';
@@ -70,9 +69,9 @@ function AppRoot() {
 }
 ```
 
-### Preconnecting in an event handler {/*preconnecting-in-an-event-handler*/}
+### Preconectando em um manipulador de eventos (event handler) {/*preconnecting-in-an-event-handler*/}
 
-Call `preconnect` in an event handler before transitioning to a page or state where external resources will be needed. This gets the process started earlier than if you call it during the rendering of the new page or state.
+Chame `preconnect` em um manipulador de eventos antes de fazer a transição para uma página ou estado onde recursos externos serão necessários. Isso inicia o processo mais cedo do que se você o chamasse durante a renderização da nova página ou estado.
 
 ```js
 import { preconnect } from 'react-dom';


### PR DESCRIPTION
This pull request contains a translation of the referenced page into Portuguese (pt-BR). The translation was generated using LLMs _(Open Router API :: model `google/gemini-2.0-flash-lite-001`)_.

Refer to the [source repository](https://github.com/NivaldoFarias/translate-react) workflow that generated this translation for more details.

Feel free to review and suggest any improvements to the translation.