### PR TITLE
Translate `passing-data-deeply-with-context.md` to Portuguese

### DIFF
--- a/src/content/learn/passing-data-deeply-with-context.md
+++ b/src/content/learn/passing-data-deeply-with-context.md
@@ -1,36 +1,36 @@
 ---
-title: Passing Data Deeply with Context
+title: Passando dados profundamente com Contexto
 ---
 
 <Intro>
 
-Usually, you will pass information from a parent component to a child component via props. But passing props can become verbose and inconvenient if you have to pass them through many components in the middle, or if many components in your app need the same information. *Context* lets the parent component make some information available to any component in the tree below it—no matter how deep—without passing it explicitly through props.
+Normalmente, você passará informações de um componente pai para um componente filho via props. Mas o envio de props pode se tornar verboso e inconveniente se você tiver que passá-las por muitos componentes no meio ou se muitos componentes em seu aplicativo precisarem das mesmas informações. O *Contexto* permite que o componente pai disponibilize algumas informações para qualquer componente na árvore abaixo dele — não importa o quão profundo — sem passá-las explicitamente por meio de props.
 
 </Intro>
 
 <YouWillLearn>
 
-- What "prop drilling" is
-- How to replace repetitive prop passing with context
-- Common use cases for context
-- Common alternatives to context
+- O que é "prop drilling"
+- Como substituir o envio repetitivo de props com contexto
+- Casos de uso comuns para contexto
+- Alternativas comuns ao contexto
 
 </YouWillLearn>
 
-## The problem with passing props {/*the-problem-with-passing-props*/}
+## O problema com o envio de props {/*the-problem-with-passing-props*/}
 
-[Passing props](/learn/passing-props-to-a-component) is a great way to explicitly pipe data through your UI tree to the components that use it.
+[Passar props](/learn/passing-props-to-a-component) é uma ótima maneira de encaminhar dados explicitamente pela sua árvore de UI para os componentes que o usam.
 
-But passing props can become verbose and inconvenient when you need to pass some prop deeply through the tree, or if many components need the same prop. The nearest common ancestor could be far removed from the components that need data, and [lifting state up](/learn/sharing-state-between-components) that high can lead to a situation called "prop drilling".
+Mas passar props pode se tornar verboso e inconveniente quando você precisa passar algumas props profundamente pela árvore, ou se muitos componentes precisam da mesma prop. O ancestral comum mais próximo pode estar muito distante dos componentes que precisam de dados, e [elevar o state](/learn/sharing-state-between-components) tão alto pode levar a uma situação chamada "prop drilling".
 
 <DiagramGroup>
 
-<Diagram name="passing_data_lifting_state" height={160} width={608} captionPosition="top" alt="Diagram with a tree of three components. The parent contains a bubble representing a value highlighted in purple. The value flows down to each of the two children, both highlighted in purple." >
+<Diagram name="passing_data_lifting_state" height={160} width={608} captionPosition="top" alt="Diagrama com uma árvore de três componentes. O pai contém uma bolha representando um valor destacado em roxo. O valor flui para baixo para cada um dos dois filhos, ambos destacados em roxo." >
 
-Lifting state up
+Elevando o state
 
 </Diagram>
-<Diagram name="passing_data_prop_drilling" height={430} width={608} captionPosition="top" alt="Diagram with a tree of ten nodes, each node with two children or less. The root node contains a bubble representing a value highlighted in purple. The value flows down through the two children, each of which pass the value but do not contain it. The left child passes the value down to two children which are both highlighted purple. The right child of the root passes the value through to one of its two children - the right one, which is highlighted purple. That child passed the value through its single child, which passes it down to both of its two children, which are highlighted purple.">
+<Diagram name="passing_data_prop_drilling" height={430} width={608} captionPosition="top" alt="Diagrama com uma árvore de dez nós, cada nó com dois filhos ou menos. O nó raiz contém uma bolha representando um valor destacado em roxo. O valor flui por meio dos dois filhos, cada um dos quais passa o valor, mas não o contém. O filho esquerdo passa o valor para dois filhos, que são ambos destacados em roxo. O filho direito da raiz passa o valor para um de seus dois filhos - o direito, que é destacado em roxo. Esse filho passou o valor por seu único filho, que o passa para seus dois filhos, que são destacados em roxo.">
 
 Prop drilling
 
@@ -38,11 +38,11 @@ Prop drilling
 
 </DiagramGroup>
 
-Wouldn't it be great if there were a way to "teleport" data to the components in the tree that need it without passing props? With React's context feature, there is!
+Não seria ótimo se houvesse uma maneira de "teletransportar" dados para os componentes da árvore que precisam deles sem passar props? Com o recurso de contexto do React, existe!
 
-## Context: an alternative to passing props {/*context-an-alternative-to-passing-props*/}
+## Contexto: uma alternativa para passar props {/*context-an-alternative-to-passing-props*/}
 
-Context lets a parent component provide data to the entire tree below it. There are many uses for context. Here is one example. Consider this `Heading` component that accepts a `level` for its size:
+O contexto permite que um componente pai forneça dados para toda a árvore abaixo dele. Existem muitos usos para o contexto. Aqui está um exemplo. Considere este componente `Heading` que aceita um `level` para seu tamanho:
 
 <Sandpack>
 
@@ -106,7 +106,7 @@ export default function Heading({ level, children }) {
 
 </Sandpack>
 
-Let's say you want multiple headings within the same `Section` to always have the same size:
+Digamos que você queira que vários cabeçalhos dentro da mesma `Section` sempre tenham o mesmo tamanho:
 
 <Sandpack>
 
@@ -180,7 +180,7 @@ export default function Heading({ level, children }) {
 
 </Sandpack>
 
-Currently, you pass the `level` prop to each `<Heading>` separately:
+Atualmente, você passa a prop `level` para cada `<Heading>` separadamente:
 
 ```js
 <Section>
@@ -190,7 +190,7 @@ Currently, you pass the `level` prop to each `<Heading>` separately:
 </Section>
 ```
 
-It would be nice if you could pass the `level` prop to the `<Section>` component instead and remove it from the `<Heading>`. This way you could enforce that all headings in the same section have the same size:
+Seria bom se você pudesse passar a prop `level` para o componente `<Section>` em vez disso e removê-la do `<Heading>`. Dessa forma, você poderia garantir que todos os cabeçalhos na mesma seção tivessem o mesmo tamanho:
 
 ```js
 <Section level={3}>
@@ -200,35 +200,35 @@ It would be nice if you could pass the `level` prop to the `<Section>` component
 </Section>
 ```
 
-But how can the `<Heading>` component know the level of its closest `<Section>`? **That would require some way for a child to "ask" for data from somewhere above in the tree.**
+Mas como o componente `<Heading>` pode saber o nível de seu `<Section>` mais próximo? **Isso exigiria alguma maneira de um filho "pedir" dados de algum lugar acima na árvore.**
 
-You can't do it with props alone. This is where context comes into play. You will do it in three steps:
+Você não pode fazer isso apenas com props. É aí que o contexto entra em jogo. Você fará isso em três etapas:
 
-1. **Create** a context. (You can call it `LevelContext`, since it's for the heading level.)
-2. **Use** that context from the component that needs the data. (`Heading` will use `LevelContext`.)
-3. **Provide** that context from the component that specifies the data. (`Section` will provide `LevelContext`.)
+1. **Crie** um contexto. (Você pode chamá-lo de `LevelContext`, pois é para o nível do cabeçalho.)
+2. **Use** esse contexto do componente que precisa dos dados. (`Heading` usará `LevelContext`.)
+3. **Forneça** esse contexto do componente que especifica os dados. (`Section` fornecerá` LevelContext`.)
 
-Context lets a parent--even a distant one!--provide some data to the entire tree inside of it.
+O contexto permite que um pai - mesmo um distante demais! - forneça alguns dados para toda a árvore dentro dele.
 
 <DiagramGroup>
 
-<Diagram name="passing_data_context_close" height={160} width={608} captionPosition="top" alt="Diagram with a tree of three components. The parent contains a bubble representing a value highlighted in orange which projects down to the two children, each highlighted in orange." >
+<Diagram name="passing_data_context_close" height={160} width={608} captionPosition="top" alt="Diagrama com uma árvore de três componentes. O pai contém uma bolha representando um valor realçado em laranja que se projeta para baixo para os dois filhos, cada um realçado em laranja." >
 
-Using context in close children
+Usando contexto em filhos próximos
 
 </Diagram>
 
-<Diagram name="passing_data_context_far" height={430} width={608} captionPosition="top" alt="Diagram with a tree of ten nodes, each node with two children or less. The root parent node contains a bubble representing a value highlighted in orange. The value projects down directly to four leaves and one intermediate component in the tree, which are all highlighted in orange. None of the other intermediate components are highlighted.">
+<Diagram name="passing_data_context_far" height={430} width={608} captionPosition="top" alt="Diagrama com uma árvore de dez nós, cada nó com dois filhos ou menos. O nó pai raiz contém uma bolha que representa um valor realçado em laranja. O valor se projeta diretamente para quatro folhas e um componente intermediário na árvore, todos realçados em laranja. Nenhum dos outros componentes intermediários está realçado.">
 
-Using context in distant children
+Usando contexto em filhos distantes
 
 </Diagram>
 
 </DiagramGroup>
 
-### Step 1: Create the context {/*step-1-create-the-context*/}
+### Etapa 1: Crie o contexto {/*step-1-create-the-context*/}
 
-First, you need to create the context. You'll need to **export it from a file** so that your components can use it:
+Primeiro, você precisa criar o contexto. Você precisará **exportá-lo de um arquivo** para que seus componentes possam usá-lo:
 
 <Sandpack>
 
@@ -308,18 +308,18 @@ export const LevelContext = createContext(1);
 
 </Sandpack>
 
-The only argument to `createContext` is the _default_ value. Here, `1` refers to the biggest heading level, but you could pass any kind of value (even an object). You will see the significance of the default value in the next step.
+O único argumento para `createContext` é o valor _padrão_. Aqui, `1` se refere ao maior nível de cabeçalho, mas você pode passar qualquer tipo de valor (até mesmo um objeto). Você verá a importância do valor padrão na próxima etapa.
 
-### Step 2: Use the context {/*step-2-use-the-context*/}
+### Etapa 2: Use o contexto {/*step-2-use-the-context*/}
 
-Import the `useContext` Hook from React and your context:
+Importe o Hook `useContext` do React e seu contexto:
 
 ```js
 import { useContext } from 'react';
 import { LevelContext } from './LevelContext.js';
 ```
 
-Currently, the `Heading` component reads `level` from props:
+Atualmente, o componente `Heading` lê o `level` das props:
 
 ```js
 export default function Heading({ level, children }) {
@@ -327,7 +327,7 @@ export default function Heading({ level, children }) {
 }
 ```
 
-Instead, remove the `level` prop and read the value from the context you just imported, `LevelContext`:
+Em vez disso, remova a prop `level` e leia o valor do contexto que você acabou de importar, `LevelContext`:
 
 ```js {2}
 export default function Heading({ children }) {
@@ -336,9 +336,9 @@ export default function Heading({ children }) {
 }
 ```
 
-`useContext` is a Hook. Just like `useState` and `useReducer`, you can only call a Hook immediately inside a React component (not inside loops or conditions). **`useContext` tells React that the `Heading` component wants to read the `LevelContext`.**
+`useContext` é um Hook. Assim como `useState` e `useReducer`, você só pode chamar um Hook imediatamente dentro de um componente React (não dentro de loops ou condições). **`useContext` informa ao React que o componente `Heading` deseja ler o `LevelContext`.**
 
-Now that the `Heading` component doesn't have a `level` prop, you don't need to pass the level prop to `Heading` in your JSX like this anymore:
+Agora que o componente `Heading` não tem uma prop `level`, você não precisa mais passar a prop de nível para `Heading` em seu JSX assim:
 
 ```js
 <Section>
@@ -348,7 +348,7 @@ Now that the `Heading` component doesn't have a `level` prop, you don't need to 
 </Section>
 ```
 
-Update the JSX so that it's the `Section` that receives it instead:
+Atualize o JSX para que seja o `Section` que o recebe:
 
 ```jsx
 <Section level={4}>
@@ -358,7 +358,7 @@ Update the JSX so that it's the `Section` that receives it instead:
 </Section>
 ```
 
-As a reminder, this is the markup that you were trying to get working:
+Como um lembrete, esta é a marcação que você estava tentando fazer funcionar:
 
 <Sandpack>
 
@@ -410,13 +410,13 @@ export default function Heading({ children }) {
     case 1:
       return <h1>{children}</h1>;
     case 2:
-      return <h2>{children}</h2>;
+      return <h2>{children}</h1>;
     case 3:
       return <h3>{children}</h3>;
     case 4:
       return <h4>{children}</h4>;
     case 5:
-      return <h5>{children}</h5>;
+      return <h5>{children}</h1>;
     case 6:
       return <h6>{children}</h6>;
     default:
@@ -442,13 +442,13 @@ export const LevelContext = createContext(1);
 
 </Sandpack>
 
-Notice this example doesn't quite work, yet! All the headings have the same size because **even though you're *using* the context, you have not *provided* it yet.** React doesn't know where to get it!
+Observe que este exemplo ainda não funciona! Todos os títulos têm o mesmo tamanho porque, **embora você esteja *usando* o contexto, você ainda não o *forneceu*.** O React não sabe onde obtê-lo!
 
-If you don't provide the context, React will use the default value you've specified in the previous step. In this example, you specified `1` as the argument to `createContext`, so `useContext(LevelContext)` returns `1`, setting all those headings to `<h1>`. Let's fix this problem by having each `Section` provide its own context.
+Se você não fornecer o contexto, o React usará o valor padrão que você especificou na etapa anterior. Neste exemplo, você especificou `1` como o argumento para `createContext`, então `useContext(LevelContext)` retorna `1`, definindo todos aqueles títulos como `<h1>`. Vamos corrigir este problema fazendo com que cada `Section` forneça seu próprio contexto.
 
-### Step 3: Provide the context {/*step-3-provide-the-context*/}
+### Etapa 3: Forneça o contexto {/*step-3-provide-the-context*/}
 
-The `Section` component currently renders its children:
+O componente `Section` atualmente renderiza seus filhos:
 
 ```js
 export default function Section({ children }) {
@@ -460,7 +460,7 @@ export default function Section({ children }) {
 }
 ```
 
-**Wrap them with a context provider** to provide the `LevelContext` to them:
+**Envolva-os com um provedor de contexto** para fornecer o `LevelContext` a eles:
 
 ```js {1,6,8}
 import { LevelContext } from './LevelContext.js';
@@ -476,7 +476,7 @@ export default function Section({ level, children }) {
 }
 ```
 
-This tells React: "if any component inside this `<Section>` asks for `LevelContext`, give them this `level`." The component will use the value of the nearest `<LevelContext.Provider>` in the UI tree above it.
+Isso diz ao React: "se algum componente dentro deste `<Section>` solicitar `LevelContext`, forneça a eles este `level`." O componente usará o valor do `<LevelContext.Provider>` mais próximo na árvore de UI acima dele.
 
 <Sandpack>
 
@@ -532,15 +532,15 @@ export default function Heading({ children }) {
     case 1:
       return <h1>{children}</h1>;
     case 2:
-      return <h2>{children}</h2>;
+      return <h2>{children}</h1>;
     case 3:
-      return <h3>{children}</h3>;
+      return <h3>{children}</h1>;
     case 4:
       return <h4>{children}</h4>;
     case 5:
-      return <h5>{children}</h5>;
+      return <h5>{children}</h1>;
     case 6:
-      return <h6>{children}</h6>;
+      return <h6>{children}</h1>;
     default:
       throw Error('Unknown level: ' + level);
   }
@@ -564,15 +564,15 @@ export const LevelContext = createContext(1);
 
 </Sandpack>
 
-It's the same result as the original code, but you did not need to pass the `level` prop to each `Heading` component! Instead, it "figures out" its heading level by asking the closest `Section` above:
+É o mesmo resultado que o código original, mas você não precisou passar a prop `level` para cada componente `Heading`! Em vez disso, ele "descobre" seu nível de cabeçalho, perguntando ao `Section` mais próximo acima:
 
-1. You pass a `level` prop to the `<Section>`.
-2. `Section` wraps its children into `<LevelContext.Provider value={level}>`.
-3. `Heading` asks the closest value of `LevelContext` above with `useContext(LevelContext)`.
+1. Você passa uma prop `level` para o `<Section>`.
+2. `Section` envolve seus filhos em `<LevelContext.Provider value=\{level\}>`.
+3. `Heading` pergunta o valor mais próximo de `LevelContext` acima com `useContext(LevelContext)`.
 
-## Using and providing context from the same component {/*using-and-providing-context-from-the-same-component*/}
+## Usando e fornecendo contexto do mesmo componente {/*using-and-providing-context-from-the-same-component*/}
 
-Currently, you still have to specify each section's `level` manually:
+Atualmente, você ainda precisa especificar o `level` de cada seção manualmente:
 
 ```js
 export default function Page() {
@@ -585,7 +585,7 @@ export default function Page() {
           ...
 ```
 
-Since context lets you read information from a component above, each `Section` could read the `level` from the `Section` above, and pass `level + 1` down automatically. Here is how you could do it:
+Como o contexto permite que você leia informações de um componente acima, cada `Section` pode ler o `level` da `Section` acima e passar `level + 1` automaticamente. Veja como você pode fazê-lo:
 
 ```js src/Section.js {5,8}
 import { useContext } from 'react';
@@ -602,8 +602,8 @@ export default function Section({ children }) {
   );
 }
 ```
-
-With this change, you don't need to pass the `level` prop *either* to the `<Section>` or to the `<Heading>`:
+``````
+## Com esta alteração, você não precisa passar a prop `level` *nem* para `<Section>` *nem* para `<Heading>`:
 
 <Sandpack>
 
@@ -695,19 +695,19 @@ export const LevelContext = createContext(0);
 
 </Sandpack>
 
-Now both `Heading` and `Section` read the `LevelContext` to figure out how "deep" they are. And the `Section` wraps its children into the `LevelContext` to specify that anything inside of it is at a "deeper" level.
+Agora tanto `Heading` quanto `Section` leem o `LevelContext` para descobrir quão "profundos" eles são. E o `Section` envolve seus filhos no `LevelContext` para especificar que qualquer coisa dentro dele está em um nível "mais profundo".
 
 <Note>
 
-This example uses heading levels because they show visually how nested components can override context. But context is useful for many other use cases too. You can pass down any information needed by the entire subtree: the current color theme, the currently logged in user, and so on.
+Este exemplo usa níveis de cabeçalho porque eles mostram visualmente como componentes aninhados podem substituir o contexto. Mas o contexto também é útil para muitos outros casos de uso. Você pode passar qualquer informação necessária pela árvore inteira: o tema de cores atual, o usuário atualmente logado e assim por diante.
 
 </Note>
 
-## Context passes through intermediate components {/*context-passes-through-intermediate-components*/}
+## O contexto passa por componentes intermediários {/*context-passes-through-intermediate-components*/}
 
-You can insert as many components as you like between the component that provides context and the one that uses it. This includes both built-in components like `<div>` and components you might build yourself.
+Você pode inserir quantos componentes quiser entre o componente que fornece o contexto e aquele que o usa. Isso inclui ambos os componentes embutidos, como `<div>` e componentes que você pode construir.
 
-In this example, the same `Post` component (with a dashed border) is rendered at two different nesting levels. Notice that the `<Heading>` inside of it gets its level automatically from the closest `<Section>`:
+Neste exemplo, o mesmo componente `Post` (com uma borda tracejada) é renderizado em dois níveis de aninhamento diferentes. Observe que o `<Heading>` dentro dele obtém seu nível automaticamente do `<Section>` mais próximo:
 
 <Sandpack>
 
@@ -832,58 +832,58 @@ export const LevelContext = createContext(0);
 
 </Sandpack>
 
-You didn't do anything special for this to work. A `Section` specifies the context for the tree inside it, so you can insert a `<Heading>` anywhere, and it will have the correct size. Try it in the sandbox above!
+Você não fez nada de especial para isso funcionar. Um `Section` especifica o contexto para a árvore dentro dele, então você pode inserir um `<Heading>` em qualquer lugar, e ele terá o tamanho correto. Experimente no sandbox acima!
 
-**Context lets you write components that "adapt to their surroundings" and display themselves differently depending on _where_ (or, in other words, _in which context_) they are being rendered.**
+**O contexto permite que você escreva componentes que "se adaptam ao seu ambiente" e se exibem de forma diferente, dependendo de _onde_ (ou, em outras palavras, _em qual contexto_) eles estão sendo renderizados.**
 
-How context works might remind you of [CSS property inheritance.](https://developer.mozilla.org/en-US/docs/Web/CSS/inheritance) In CSS, you can specify `color: blue` for a `<div>`, and any DOM node inside of it, no matter how deep, will inherit that color unless some other DOM node in the middle overrides it with `color: green`. Similarly, in React, the only way to override some context coming from above is to wrap children into a context provider with a different value.
+Como o contexto funciona pode lembrá-lo da [herança de propriedade CSS.](https://developer.mozilla.org/en-US/docs/Web/CSS/inheritance) Em CSS, você pode especificar `color: blue` para um `<div>`, e qualquer nó do DOM dentro dele, não importa quão profundo, herdará essa cor, a menos que algum outro nó do DOM no meio o substitua com `color: green`. Da mesma forma, no React, a única maneira de substituir algum contexto vindo de cima é envolver os filhos em um provedor de contexto com um valor diferente.
 
-In CSS, different properties like `color` and `background-color` don't override each other. You can set all  `<div>`'s `color` to red without impacting `background-color`. Similarly, **different React contexts don't override each other.** Each context that you make with `createContext()` is completely separate from other ones, and ties together components using and providing *that particular* context. One component may use or provide many different contexts without a problem.
+Em CSS, propriedades diferentes como `color` e `background-color` não se sobrepõem. Você pode definir a `color` de todos os `<div>` para vermelho sem impactar `background-color`. Da mesma forma, **contextos React diferentes não se sobrepõem.** Cada contexto que você faz com `createContext()` é completamente separado dos outros e une componentes usando e fornecendo *aquele contexto em particular*. Um componente pode usar ou fornecer muitos contextos diferentes sem problemas.
 
-## Before you use context {/*before-you-use-context*/}
+## Antes de usar o contexto {/*before-you-use-context*/}
 
-Context is very tempting to use! However, this also means it's too easy to overuse it. **Just because you need to pass some props several levels deep doesn't mean you should put that information into context.**
+O contexto é muito tentador de usar! No entanto, isso também significa que é muito fácil usá-lo em excesso. **Só porque você precisa passar algumas props vários níveis abaixo não significa que você deve colocar essa informação no contexto.**
 
-Here's a few alternatives you should consider before using context:
+Aqui estão algumas alternativas que você deve considerar antes de usar contexto:
 
-1. **Start by [passing props.](/learn/passing-props-to-a-component)** If your components are not trivial, it's not unusual to pass a dozen props down through a dozen components. It may feel like a slog, but it makes it very clear which components use which data! The person maintaining your code will be glad you've made the data flow explicit with props.
-2. **Extract components and [pass JSX as `children`](/learn/passing-props-to-a-component#passing-jsx-as-children) to them.** If you pass some data through many layers of intermediate components that don't use that data (and only pass it further down), this often means that you forgot to extract some components along the way. For example, maybe you pass data props like `posts` to visual components that don't use them directly, like `<Layout posts={posts} />`. Instead, make `Layout` take `children` as a prop, and render `<Layout><Posts posts={posts} /></Layout>`. This reduces the number of layers between the component specifying the data and the one that needs it.
+1. **Comece [passando props.](/learn/passing-props-to-a-component)** Se seus componentes não são triviais, não é incomum passar uma dúzia de props por meio de uma dúzia de componentes. Pode parecer um esforço, mas torna muito claro quais componentes usam quais dados! A pessoa que mantém seu código ficará feliz por você ter tornado o fluxo de dados explícito com as props.
+2. **Extraia componentes e [passe JSX como `children`](/learn/passing-props-to-a-component#passing-jsx-as-children) para eles.** Se você passar alguns dados por muitas camadas de componentes intermediários que não usam esses dados (e apenas os passam adiante), isso geralmente significa que você esqueceu de extrair alguns componentes ao longo do caminho. Por exemplo, talvez você passe dados de props como `posts` para componentes visuais que não os usam diretamente, como `<Layout posts={posts} />`. Em vez disso, faça com que `Layout` aceite `children` como uma prop e renderize `<Layout><Posts posts={posts} /></Layout>`. Isso reduz o número de camadas entre o componente que especifica os dados e aquele que precisa deles.
 
-If neither of these approaches works well for you, consider context.
+Se nenhuma dessas abordagens funcionar bem para você, considere o contexto.
 
-## Use cases for context {/*use-cases-for-context*/}
+## Casos de uso para contexto {/*use-cases-for-context*/}
 
-* **Theming:** If your app lets the user change its appearance (e.g. dark mode), you can put a context provider at the top of your app, and use that context in components that need to adjust their visual look.
-* **Current account:** Many components might need to know the currently logged in user. Putting it in context makes it convenient to read it anywhere in the tree. Some apps also let you operate multiple accounts at the same time (e.g. to leave a comment as a different user). In those cases, it can be convenient to wrap a part of the UI into a nested provider with a different current account value.
-* **Routing:** Most routing solutions use context internally to hold the current route. This is how every link "knows" whether it's active or not. If you build your own router, you might want to do it too.
-* **Managing state:** As your app grows, you might end up with a lot of state closer to the top of your app. Many distant components below may want to change it. It is common to [use a reducer together with context](/learn/scaling-up-with-reducer-and-context) to manage complex state and pass it down to distant components without too much hassle.
-  
-Context is not limited to static values. If you pass a different value on the next render, React will update all the components reading it below! This is why context is often used in combination with state.
+*   **Theming:** Se seu aplicativo permite que o usuário altere sua aparência (por exemplo, modo escuro), você pode colocar um provedor de contexto no topo do seu aplicativo e usar esse contexto em componentes que precisam ajustar sua aparência visual.
+*   **Conta atual:** Muitos componentes podem precisar saber o usuário atualmente logado. Colocá-lo em contexto torna conveniente lê-lo em qualquer lugar na árvore. Alguns aplicativos também permitem que você opere várias contas ao mesmo tempo (por exemplo, para deixar um comentário como um usuário diferente). Nesses casos, pode ser conveniente envolver uma parte da interface do usuário em um provedor aninhado com um valor de conta atual diferente.
+*   **Roteamento:** A maioria das soluções de roteamento usa o contexto internamente para manter a rota atual. É assim que cada link "sabe" se está ativo ou não. Se você construir seu próprio roteador, talvez queira fazê-lo também.
+*   **Gerenciando estado:** Conforme seu aplicativo cresce, você pode acabar com muito estado mais próximo do topo do seu aplicativo. Muitos componentes distantes abaixo podem querer alterá-lo. É comum [usar um redutor junto com o contexto](/learn/scaling-up-with-reducer-and-context) para gerenciar estado complexo e passá-lo para componentes distantes sem muito incômodo.
 
-In general, if some information is needed by distant components in different parts of the tree, it's a good indication that context will help you.
+O contexto não se limita a valores estáticos. Se você passar um valor diferente na próxima renderização, o React atualizará todos os componentes que o lêem abaixo! É por isso que o contexto é frequentemente usado em combinação com o estado.
+
+Em geral, se alguma informação é necessária por componentes distantes em diferentes partes da árvore, é um bom indício de que o contexto o ajudará.
 
 <Recap>
 
-* Context lets a component provide some information to the entire tree below it.
-* To pass context:
-  1. Create and export it with `export const MyContext = createContext(defaultValue)`.
-  2. Pass it to the `useContext(MyContext)` Hook to read it in any child component, no matter how deep.
-  3. Wrap children into `<MyContext.Provider value={...}>` to provide it from a parent.
-* Context passes through any components in the middle.
-* Context lets you write components that "adapt to their surroundings".
-* Before you use context, try passing props or passing JSX as `children`.
+*   O contexto permite que um componente forneça algumas informações para toda a árvore abaixo dele.
+*   Para passar contexto:
+    1.  Crie e exporte-o com `export const MyContext = createContext(defaultValue)`.
+    2.  Passe-o para o Hook `useContext(MyContext)` para lê-lo em qualquer componente filho, não importa o quão profundo.
+    3.  Envolva os filhos em `<MyContext.Provider value={...}>` para fornecê-lo de um pai.
+*   O contexto passa por quaisquer componentes no meio.
+*   O contexto permite que você escreva componentes que "se adaptam ao seu ambiente".
+*   Antes de usar o contexto, tente passar props ou passar JSX como `children`.
 
 </Recap>
 
 <Challenges>
 
-#### Replace prop drilling with context {/*replace-prop-drilling-with-context*/}
+#### Substituir prop drilling com contexto {/*replace-prop-drilling-with-context*/}
 
-In this example, toggling the checkbox changes the `imageSize` prop passed to each `<PlaceImage>`. The checkbox state is held in the top-level `App` component, but each `<PlaceImage>` needs to be aware of it.
+Neste exemplo, alternar a caixa de seleção altera a prop `imageSize` passada para cada `<PlaceImage>`. O estado da caixa de seleção é mantido no componente `App` de nível superior, mas cada `<PlaceImage>` precisa estar ciente dele.
 
-Currently, `App` passes `imageSize` to `List`, which passes it to each `Place`, which passes it to the `PlaceImage`. Remove the `imageSize` prop, and instead pass it from the `App` component directly to `PlaceImage`.
+Atualmente, `App` passa `imageSize` para `List`, que passa para cada `Place`, que passa para o `PlaceImage`. Remova a prop `imageSize` e, em vez disso, passe-a do componente `App` diretamente para `PlaceImage`.
 
-You can declare context in `Context.js`.
+Você pode declarar o contexto em `Context.js`.
 
 <Sandpack>
 
@@ -975,7 +975,7 @@ export const places = [{
 }, {
   id: 3, 
   name: 'Selarón Staircase in Rio de Janeiro, Brazil',
-  description: 'This landmark was created by Jorge Selarón, a Chilean-born artist, as a "tribute to the Brazilian people."',
+  description: 'This landmark was created by Jorge Selarón, a Chilean-born artist, as a "tribute to the Brazilian people".',
   imageId: 'aeO3rpI'
 }, {
   id: 4, 
@@ -1020,9 +1020,9 @@ li {
 
 <Solution>
 
-Remove `imageSize` prop from all the components.
+Remova a prop `imageSize` de todos os componentes.
 
-Create and export `ImageSizeContext` from `Context.js`. Then wrap the List into `<ImageSizeContext.Provider value={imageSize}>` to pass the value down, and `useContext(ImageSizeContext)` to read it in the `PlaceImage`:
+Crie e exporte `ImageSizeContext` de `Context.js`. Em seguida, envolva a Lista em `<ImageSizeContext.Provider value={imageSize}>` para passar o valor, e `useContext(ImageSizeContext)` para lê-lo no `PlaceImage`:
 
 <Sandpack>
 
@@ -1157,8 +1157,9 @@ li {
 
 </Sandpack>
 
-Note how components in the middle don't need to pass `imageSize` anymore.
+Observe como os componentes no meio não precisam mais passar `imageSize`.
 
 </Solution>
 
 </Challenges>
+```


### PR DESCRIPTION
This pull request contains a translation of the referenced page into Portuguese (pt-BR). The translation was generated using LLMs _(Open Router API :: model `google/gemini-2.0-flash-lite-001`)_.

Refer to the [source repository](https://github.com/NivaldoFarias/translate-react) workflow that generated this translation for more details.

Feel free to review and suggest any improvements to the translation.