### PR TITLE
Translate `index.md` to Brazilian Portuguese

### DIFF
--- a/src/content/reference/react-dom/index.md
+++ b/src/content/reference/react-dom/index.md
@@ -1,6 +1,6 @@
----
+```md
 title: React DOM APIs
----
+```
 
 <Intro>
 
@@ -19,16 +19,16 @@ Essas APIs podem ser importadas em seus componentes. Elas são raramente usadas:
 
 ## Resource Preloading APIs {/*resource-preloading-apis*/}
 
-These APIs can be used to make apps faster by pre-loading resources such as scripts, stylesheets, and fonts as soon as you know you need them, for example before navigating to another page where the resources will be used.
+Essas APIs podem ser usadas para tornar os aplicativos mais rápidos, pré-carregando recursos como scripts, folhas de estilo e fontes assim que você souber que precisa deles, por exemplo, antes de navegar para outra página onde os recursos serão usados.
 
-[React-based frameworks](/learn/start-a-new-react-project) frequently handle resource loading for you, so you might not have to call these APIs yourself. Consult your framework's documentation for details.
+[Frameworks baseados em React](/learn/start-a-new-react-project) frequentemente lidam com o carregamento de recursos para você, então você pode não precisar chamar essas APIs. Consulte a documentação do seu framework para obter detalhes.
 
-* [`prefetchDNS`](/reference/react-dom/prefetchDNS) lets you prefetch the IP address of a DNS domain name that you expect to connect to.
-* [`preconnect`](/reference/react-dom/preconnect) lets you connect to a server you expect to request resources from, even if you don't know what resources you'll need yet.
-* [`preload`](/reference/react-dom/preload) lets you fetch a stylesheet, font, image, or external script that you expect to use.
-* [`preloadModule`](/reference/react-dom/preloadModule) lets you fetch an ESM module that you expect to use.
-* [`preinit`](/reference/react-dom/preinit) lets you fetch and evaluate an external script or fetch and insert a stylesheet.
-* [`preinitModule`](/reference/react-dom/preinitModule) lets you fetch and evaluate an ESM module.
+* [`prefetchDNS`](/reference/react-dom/prefetchDNS) permite pré-carregar o endereço IP de um nome de domínio DNS com o qual você espera se conectar.
+* [`preconnect`](/reference/react-dom/preconnect) permite que você se conecte a um servidor do qual espera solicitar recursos, mesmo que ainda não saiba quais recursos precisará.
+* [`preload`](/reference/react-dom/preload) permite buscar uma folha de estilo, fonte, imagem ou script externo que você espera usar.
+* [`preloadModule`](/reference/react-dom/preloadModule) permite buscar um módulo ESM que você espera usar.
+* [`preinit`](/reference/react-dom/preinit) permite buscar e avaliar um script externo ou buscar e inserir uma folha de estilo.
+* [`preinitModule`](/reference/react-dom/preinitModule) permite buscar e avaliar um módulo ESM.
 
 ---
 
@@ -51,3 +51,4 @@ Essas APIs foram removidas no React 19:
 * [`unmountComponentAtNode`](/reference/react-dom/unmountComponentAtNode): use [`root.unmount()`](/reference/react-dom/client/createRoot#root-unmount) em vez disso.
 * [`renderToNodeStream`](https://18.react.dev/reference/react-dom/server/renderToNodeStream): use as APIs de [`react-dom/server`](/reference/react-dom/server) em vez disso.
 * [`renderToStaticNodeStream`](https://18.react.dev/reference/react-dom/server/renderToStaticNodeStream): use as APIs de [`react-dom/server`](/reference/react-dom/server) em vez disso.
+```


### PR DESCRIPTION
This pull request contains an automated translation of the referenced page to **Brazilian Portuguese**.

> [!IMPORTANT]
> This translation was generated using AI/LLM technology and requires human review for accuracy, cultural context, and technical terminology.

## Review Guidelines

Please review this translation for:

- [ ] **Accuracy**: Content meaning preserved from source
- [ ] **Technical Terms**: Proper translation of React/development terminology
- [ ] **Cultural Context**: Appropriate localization for target audience
- [ ] **Formatting**: Markdown syntax and code blocks maintained
- [ ] **Links**: Internal references and external links work correctly

<details>
<summary>Translation Details</summary>

### Processing Statistics

| Metric | Value |
|--------|-------|
| **Source File Size** | 3.2 KB |
| **Translation Size** | 3.3 KB |
| **Content Ratio** | 1.03x |
| **File Path** | `src/content/reference/react-dom/index.md` |
| **Processing Time** | ~223s |

###### ps.: The content ratio indicates how the translation length compares to the source (1.0x = same length, >1.0x = translation is longer). Different languages naturally have varying verbosity levels.

### Technical Information

- **Target Language**: Brazilian Portuguese (`pt-br`)
- **AI Model**: `google/gemini-2.5-flash-lite` via Open Router API
- **Generated**: 2025-10-07
- **Branch**: `refs/heads/translate/reference/react-dom/index.md`
- **Translation Tool Version**: `translate-react v0.1.7`


</details>

## Additional Resources

- [Source Repository](https://github.com/NivaldoFarias/translate-react): Workflow and tooling details
- [Translation Workflow Documentation](https://github.com/NivaldoFarias/translate-react#readme): Process overview and guidelines

---

**Questions or suggestions?** Feel free to leave comments or request changes to improve the translation quality.