### PR TITLE
Translate `captureOwnerStack.md` to Brazilian Portuguese

### DIFF
--- a/src/content/reference/react/captureOwnerStack.md
+++ b/src/content/reference/react/captureOwnerStack.md
@@ -1,10 +1,6 @@
----
-title: captureOwnerStack
----
-
 <Intro>
 
-`captureOwnerStack` reads the current Owner Stack in development and returns it as a string if available.
+`captureOwnerStack` lê a Pilha de Proprietários (Owner Stack) atual em desenvolvimento e a retorna como uma string, se disponível.
 
 ```js
 const stack = captureOwnerStack();
@@ -16,11 +12,11 @@ const stack = captureOwnerStack();
 
 ---
 
-## Reference {/*reference*/}
+## Referência {/*reference*/}
 
 ### `captureOwnerStack()` {/*captureownerstack*/}
 
-Call `captureOwnerStack` to get the current Owner Stack.
+Chame `captureOwnerStack` para obter a Pilha de Proprietários atual.
 
 ```js {5,5}
 import * as React from 'react';
@@ -33,33 +29,33 @@ function Component() {
 }
 ```
 
-#### Parameters {/*parameters*/}
+#### Parâmetros {/*parameters*/}
 
-`captureOwnerStack` does not take any parameters.
+`captureOwnerStack` não recebe parâmetros.
 
-#### Returns {/*returns*/}
+#### Retorna {/*returns*/}
 
-`captureOwnerStack` returns `string | null`.
+`captureOwnerStack` retorna `string | null`.
 
-Owner Stacks are available in
-- Component render
-- Effects (e.g. `useEffect`)
-- React's event handlers (e.g. `<button onClick={...} />`)
-- React error handlers ([React Root options](/reference/react-dom/client/createRoot#parameters) `onCaughtError`, `onRecoverableError`, and `onUncaughtError`)
+As Pilhas de Proprietários estão disponíveis em:
+- Renderização de Componentes
+- Efeitos (ex: `useEffect`)
+- Manipuladores de eventos do React (ex: `<button onClick={...} />`)
+- Manipuladores de erro do React ([Opções do React Root](/reference/react-dom/client/createRoot#parameters) `onCaughtError`, `onRecoverableError` e `onUncaughtError`)
 
-If no Owner Stack is available, `null` is returned (see [Troubleshooting: The Owner Stack is `null`](#the-owner-stack-is-null)).
+Se nenhuma Pilha de Proprietários estiver disponível, `null` é retornado (veja [Solução de Problemas: A Pilha de Proprietários é `null`](#the-owner-stack-is-null)).
 
-#### Caveats {/*caveats*/}
+#### Ressalvas {/*caveats*/}
 
-- Owner Stacks are only available in development. `captureOwnerStack` will always return `null` outside of development.
+- As Pilhas de Proprietários estão disponíveis apenas em desenvolvimento. `captureOwnerStack` sempre retornará `null` fora do ambiente de desenvolvimento.
 
 <DeepDive>
 
-#### Owner Stack vs Component Stack {/*owner-stack-vs-component-stack*/}
+#### Pilha de Proprietários vs. Pilha de Componentes {/*owner-stack-vs-component-stack*/}
 
-The Owner Stack is different from the Component Stack available in React error handlers like [`errorInfo.componentStack` in `onUncaughtError`](/reference/react-dom/client/hydrateRoot#error-logging-in-production).
+A Pilha de Proprietários é diferente da Pilha de Componentes disponível em manipuladores de erro do React, como `errorInfo.componentStack` em `onUncaughtError` ([`/reference/react-dom/client/hydrateRoot#error-logging-in-production`](/reference/react-dom/client/hydrateRoot#error-logging-in-production)).
 
-For example, consider the following code:
+Por exemplo, considere o seguinte código:
 
 <Sandpack>
 
@@ -105,11 +101,11 @@ import './styles.css';
 
 createRoot(document.createElement('div'), {
   onUncaughtError: (error, errorInfo) => {
-    // The stacks are logged instead of showing them in the UI directly to
-    // highlight that browsers will apply sourcemaps to the logged stacks.
-    // Note that sourcemapping is only applied in the real browser console not
-    // in the fake one displayed on this page.
-    // Press "fork" to be able to view the sourcemapped stack in a real console.
+    // As pilhas são registradas em log em vez de serem exibidas diretamente na UI para
+    // destacar que os navegadores aplicarão sourcemaps às pilhas registradas.
+    // Observe que o sourcemapping é aplicado apenas no console real do navegador, não
+    // no console falso exibido nesta página.
+    // Pressione "fork" para poder visualizar a pilha com sourcemap em um console real.
     console.log(errorInfo.componentStack);
     console.log(captureOwnerStack());
   },
@@ -136,8 +132,8 @@ createRoot(document.createElement('div'), {
 
 </Sandpack>
 
-`SubComponent` would throw an error.
-The Component Stack of that error would be
+`SubComponent` lançaria um erro.
+A Pilha de Componentes desse erro seria:
 
 ```
 at SubComponent
@@ -148,23 +144,23 @@ at React.Suspense
 at App
 ```
 
-However, the Owner Stack would only read
+No entanto, a Pilha de Proprietários leria apenas:
 
 ```
 at Component
 ```
 
-Neither `App` nor the DOM components (e.g. `fieldset`) are considered Owners in this Stack since they didn't contribute to "creating" the node containing `SubComponent`. `App` and DOM components only forwarded the node. `App` just rendered the `children` node as opposed to `Component` which created a node containing `SubComponent` via `<SubComponent />`.
+Nem `App` nem os componentes DOM (ex: `fieldset`) são considerados Proprietários nesta Pilha, pois não contribuíram para "criar" o nó que contém `SubComponent`. `App` e os componentes DOM apenas encaminharam o nó. `App` apenas renderizou o nó `children`, em oposição a `Component`, que criou um nó contendo `SubComponent` via `<SubComponent />`.
 
-Neither `Navigation` nor `legend` are in the stack at all since it's only a sibling to a node containing `<SubComponent />`.
+Nem `Navigation` nem `legend` estão na pilha, pois são apenas irmãos de um nó contendo `<SubComponent />`.
 
-`SubComponent` is omitted because it's already part of the callstack.
+`SubComponent` é omitido porque já faz parte da pilha de chamadas.
 
 </DeepDive>
 
-## Usage {/*usage*/}
+## Uso {/*usage*/}
 
-### Enhance a custom error overlay {/*enhance-a-custom-error-overlay*/}
+### Aprimorar uma sobreposição de erro personalizada {/*enhance-a-custom-error-overlay*/}
 
 ```js [[1, 5, "console.error"], [4, 7, "captureOwnerStack"]]
 import { captureOwnerStack } from "react";
@@ -183,7 +179,7 @@ console.error = function patchedConsoleError(...args) {
 };
 ```
 
-If you intercept <CodeStep step={1}>`console.error`</CodeStep> calls to highlight them in an error overlay, you can call <CodeStep step={2}>`captureOwnerStack`</CodeStep> to include the Owner Stack.
+Se você interceptar chamadas de <CodeStep step={1}>`console.error`</CodeStep> para destacá-las em uma sobreposição de erro, você pode chamar <CodeStep step={2}>`captureOwnerStack`</CodeStep> para incluir a Pilha de Proprietários.
 
 <Sandpack>
 
@@ -347,13 +343,13 @@ export default function App() {
 
 </Sandpack>
 
-## Troubleshooting {/*troubleshooting*/}
+## Solução de Problemas {/*troubleshooting*/}
 
-### The Owner Stack is `null` {/*the-owner-stack-is-null*/}
+### A Pilha de Proprietários é `null` {/*the-owner-stack-is-null*/}
 
-The call of `captureOwnerStack` happened outside of a React controlled function e.g. in a `setTimeout` callback, after a `fetch` call or in a custom DOM event handler. During render, Effects, React event handlers, and React error handlers (e.g. `hydrateRoot#options.onCaughtError`) Owner Stacks should be available.
+A chamada de `captureOwnerStack` ocorreu fora de uma função controlada pelo React, por exemplo, em um callback de `setTimeout`, após uma chamada `fetch` ou em um manipulador de eventos DOM personalizado. Durante a renderização, Efeitos, manipuladores de eventos do React e manipuladores de erro do React (ex: `hydrateRoot#options.onCaughtError`), as Pilhas de Proprietários devem estar disponíveis.
 
-In the example below, clicking the button will log an empty Owner Stack because `captureOwnerStack` was called during a custom DOM event handler. The Owner Stack must be captured earlier e.g. by moving the call of `captureOwnerStack` into the Effect body.
+No exemplo abaixo, clicar no botão registrará uma Pilha de Proprietários vazia porque `captureOwnerStack` foi chamado durante um manipulador de eventos DOM personalizado. A Pilha de Proprietários deve ser capturada anteriormente, por exemplo, movendo a chamada de `captureOwnerStack` para o corpo do Efeito.
 <Sandpack>
 
 ```js
@@ -381,9 +377,9 @@ export default function App() {
 
 </Sandpack>
 
-### `captureOwnerStack` is not available {/*captureownerstack-is-not-available*/}
+### `captureOwnerStack` não está disponível {/*captureownerstack-is-not-available*/}
 
-`captureOwnerStack` is only exported in development builds. It will be `undefined` in production builds. If `captureOwnerStack` is used in files that are bundled for production and development, you should conditionally access it from a namespace import.
+`captureOwnerStack` é exportado apenas em builds de desenvolvimento. Será `undefined` em builds de produção. Se `captureOwnerStack` for usado em arquivos que são empacotados para produção e desenvolvimento, você deve acessá-lo condicionalmente a partir de uma importação de namespace.
 
 ```js
 // Don't use named imports of `captureOwnerStack` in files that are bundled for development and production.


### PR DESCRIPTION
This pull request contains an automated translation of the referenced page to **Brazilian Portuguese**.

> [!IMPORTANT]
> This translation was generated using AI/LLM technology and requires human review for accuracy, cultural context, and technical terminology.

## Review Guidelines

Please review this translation for:

- [ ] **Accuracy**: Content meaning preserved from source
- [ ] **Technical Terms**: Proper translation of React/development terminology
- [ ] **Cultural Context**: Appropriate localization for target audience
- [ ] **Formatting**: Markdown syntax and code blocks maintained
- [ ] **Links**: Internal references and external links work correctly

<details>
<summary>Translation Details</summary>

### Processing Statistics

| Metric | Value |
|--------|-------|
| **Source File Size** | 9.7 KB |
| **Translation Size** | 10.1 KB |
| **Content Ratio** | 1.05x |
| **File Path** | `src/content/reference/react/captureOwnerStack.md` |
| **Processing Time** | ~247s |

###### ps.: The content ratio indicates how the translation length compares to the source (1.0x = same length, >1.0x = translation is longer). Different languages naturally have varying verbosity levels.

### Technical Information

- **Target Language**: Brazilian Portuguese (`pt-br`)
- **AI Model**: `google/gemini-2.5-flash-lite` via Open Router API
- **Generated**: 2025-10-07
- **Branch**: `refs/heads/translate/reference/react/captureOwnerStack.md`
- **Translation Tool Version**: `translate-react v0.1.7`


</details>

## Additional Resources

- [Source Repository](https://github.com/NivaldoFarias/translate-react): Workflow and tooling details
- [Translation Workflow Documentation](https://github.com/NivaldoFarias/translate-react#readme): Process overview and guidelines

---

**Questions or suggestions?** Feel free to leave comments or request changes to improve the translation quality.