### PR TITLE
Translate `react-developer-tools.md` to Brazilian Portuguese

### DIFF
--- a/src/content/learn/react-developer-tools.md
+++ b/src/content/learn/react-developer-tools.md
@@ -19,8 +19,8 @@ Use a ferramenta de desenvolvedor do React para inspecionar [componentes](/learn
 
 A forma mais fácil de depurar websites construídos com React é instalar a ferramenta de desenvolvedor do React no navegador. Ela está disponível para vários navegadores populares:
 
-* [Instalar para **Chrome**](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=en)
-* [Instalar para **Firefox**](https://addons.mozilla.org/en-US/firefox/addon/react-devtools/)
+* [Instalar para **Chrome**](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=pt-BR)
+* [Instalar para **Firefox**](https://addons.mozilla.org/pt-BR/firefox/addon/react-devtools/)
 * [Instalar para **Edge**](https://microsoftedge.microsoft.com/addons/detail/react-developer-tools/gpphkfbcpidddadnkolkpfckpihlkkil)
 
 Agora, se você visitar um website **construído com React**, você verá os painéis _Components_ e _Profiler_.


### PR DESCRIPTION
This pull request contains an automated translation of the referenced page to **Brazilian Portuguese**.


> [!IMPORTANT]
> This translation was generated using AI/LLM and requires human review for accuracy, cultural context, and technical terminology.

<details>
<summary>Translation Details</summary>

### Processing Statistics

| Metric | Value |
|--------|-------|
| **Source File Size** | 2.6 KB |
| **Translation Size** | 2.6 KB |
| **Content Ratio** | 1.00x |
| **File Path** | `src/content/learn/react-developer-tools.md` |
| **Processing Time** | ~2620s |

###### ps.: The content ratio indicates how the translation length compares to the source (1.0x = same length, >1.0x = translation is longer). Different languages naturally have varying verbosity levels.

### Technical Information

- **Target Language**: Brazilian Portuguese (`pt-br`)
- **AI Model**: `google/gemini-2.5-flash-lite` via Open Router API
- **Generated**: 2025-12-18
- **Branch**: `refs/heads/translate/learn/react-developer-tools.md`
- **Translation Tool Version**: `translate-react v0.1.17`


</details>

## Additional Resources

- [Source Repository](https://github.com/NivaldoFarias/translate-react): Workflow and tooling details
- [Translation Workflow Documentation](https://github.com/NivaldoFarias/translate-react#readme): Process overview and guidelines