### PR TITLE
Translate `gating.md` to Brazilian Portuguese

### DIFF
--- a/src/content/reference/react-compiler/gating.md
+++ b/src/content/reference/react-compiler/gating.md
@@ -4,7 +4,7 @@ title: gating
 
 <Intro>
 
-The `gating` option enables conditional compilation, allowing you to control when optimized code is used at runtime.
+A opção `gating` habilita a compilação condicional, permitindo que você controle quando o código otimizado é usado em tempo de execução.
 
 </Intro>
 
@@ -21,13 +21,13 @@ The `gating` option enables conditional compilation, allowing you to control whe
 
 ---
 
-## Reference {/*reference*/}
+## Referência {/*reference*/}
 
 ### `gating` {/*gating*/}
 
-Configures runtime feature flag gating for compiled functions.
+Configura o gating de feature flags em tempo de execução para funções compiladas.
 
-#### Type {/*type*/}
+#### Tipo {/*type*/}
 
 ```
 {
@@ -36,38 +36,38 @@ Configures runtime feature flag gating for compiled functions.
 } | null
 ```
 
-#### Default value {/*default-value*/}
+#### Valor padrão {/*default-value*/}
 
 `null`
 
-#### Properties {/*properties*/}
+#### Propriedades {/*properties*/}
 
-- **`source`**: Module path to import the feature flag from
-- **`importSpecifierName`**: Name of the exported function to import
+- **`source`**: Caminho do módulo para importar a feature flag.
+- **`importSpecifierName`**: Nome da função exportada a ser importada.
 
-#### Caveats {/*caveats*/}
+#### Ressalvas {/*caveats*/}
 
-- The gating function must return a boolean
-- Both compiled and original versions increase bundle size
-- The import is added to every file with compiled functions
+- A função de gating deve retornar um booleano.
+- Tanto a versão compilada quanto a original aumentam o tamanho do bundle.
+- A importação é adicionada a todos os arquivos com funções compiladas.
 
 ---
 
-## Usage {/*usage*/}
+## Uso {/*usage*/}
 
-### Basic feature flag setup {/*basic-setup*/}
+### Configuração básica de feature flag {/*basic-setup*/}
 
-1. Create a feature flag module:
+1. Crie um módulo de feature flag:
 
 ```js
 // src/utils/feature-flags.js
 export function shouldUseCompiler() {
-  // your logic here
+  // sua lógica aqui
   return getFeatureFlag('react-compiler-enabled');
 }
 ```
 
-2. Configure the compiler:
+2. Configure o compilador:
 
 ```js
 {
@@ -78,62 +78,62 @@ export function shouldUseCompiler() {
 }
 ```
 
-3. The compiler generates gated code:
+3. O compilador gera código com gating:
 
 ```js
-// Input
+// Entrada
 function Button(props) {
   return <button>{props.label}</button>;
 }
 
-// Output (simplified)
+// Saída (simplificada)
 import { shouldUseCompiler } from './src/utils/feature-flags';
 
 const Button = shouldUseCompiler()
-  ? function Button_optimized(props) { /* compiled version */ }
-  : function Button_original(props) { /* original version */ };
+  ? function Button_optimized(props) { /* versão compilada */ }
+  : function Button_original(props) { /* versão original */ };
 ```
 
-Note that the gating function is evaluated once at module time, so once the JS bundle has been parsed and evaluated the choice of component stays static for the rest of the browser session.
+Note que a função de gating é avaliada uma vez no tempo de módulo, então, assim que o bundle JS for analisado e avaliado, a escolha do componente permanecerá estática pelo resto da sessão do navegador.
 
 ---
 
-## Troubleshooting {/*troubleshooting*/}
+## Solução de problemas {/*troubleshooting*/}
 
-### Feature flag not working {/*flag-not-working*/}
+### Feature flag não está funcionando {/*flag-not-working*/}
 
-Verify your flag module exports the correct function:
+Verifique se o seu módulo de flag exporta a função correta:
 
 ```js
-// ❌ Wrong: Default export
+// ❌ Errado: Exportação padrão
 export default function shouldUseCompiler() {
   return true;
 }
 
-// ✅ Correct: Named export matching importSpecifierName
+// ✅ Correto: Exportação nomeada correspondendo a importSpecifierName
 export function shouldUseCompiler() {
   return true;
 }
 ```
 
-### Import errors {/*import-errors*/}
+### Erros de importação {/*import-errors*/}
 
-Ensure the source path is correct:
+Certifique-se de que o caminho da origem está correto:
 
 ```js
-// ❌ Wrong: Relative to babel.config.js
+// ❌ Errado: Relativo a babel.config.js
 {
   source: './src/flags',
   importSpecifierName: 'flag'
 }
 
-// ✅ Correct: Module resolution path
+// ✅ Correto: Caminho de resolução de módulo
 {
   source: '@myapp/feature-flags',
   importSpecifierName: 'flag'
 }
 
-// ✅ Also correct: Absolute path from project root
+// ✅ Também correto: Caminho absoluto a partir da raiz do projeto
 {
   source: './src/utils/flags',
   importSpecifierName: 'flag'


### PR DESCRIPTION
This pull request contains an automated translation of the referenced page to **Brazilian Portuguese**.


> [!IMPORTANT]
> This translation was generated using AI/LLM and requires human review for accuracy, cultural context, and technical terminology.

<details>
<summary>Translation Details</summary>

### Processing Statistics

| Metric | Value |
|--------|-------|
| **Source File Size** | 2.6 KB |
| **Translation Size** | 2.8 KB |
| **Content Ratio** | 1.07x |
| **File Path** | `src/content/reference/react-compiler/gating.md` |
| **Processing Time** | ~5086s |

###### ps.: The content ratio indicates how the translation length compares to the source (1.0x = same length, >1.0x = translation is longer). Different languages naturally have varying verbosity levels.

### Technical Information

- **Target Language**: Brazilian Portuguese (`pt-br`)
- **AI Model**: `google/gemini-2.5-flash-lite` via Open Router API
- **Generated**: 2025-12-18
- **Branch**: `refs/heads/translate/reference/react-compiler/gating.md`
- **Translation Tool Version**: `translate-react v0.1.17`


</details>

## Additional Resources

- [Source Repository](https://github.com/NivaldoFarias/translate-react): Workflow and tooling details
- [Translation Workflow Documentation](https://github.com/NivaldoFarias/translate-react#readme): Process overview and guidelines