### PR TITLE
Translate `index.md` to Brazilian Portuguese

### DIFF
--- a/src/content/reference/react-dom/index.md
+++ b/src/content/reference/react-dom/index.md
@@ -1,5 +1,5 @@
 ---
-title: React DOM APIs
+title: APIs do React DOM
 ---
 
 <Intro>
@@ -17,22 +17,22 @@ Essas APIs podem ser importadas em seus componentes. Elas são raramente usadas:
 * [`createPortal`](/reference/react-dom/createPortal) permite renderizar componentes filhos em uma parte diferente da árvore DOM.
 * [`flushSync`](/reference/react-dom/flushSync) permite forçar o React a atualizar o estado e atualizar o DOM sincronamente.
 
-## Resource Preloading APIs {/*resource-preloading-apis*/}
+## APIs de Pré-carregamento de Recursos {/*resource-preloading-apis*/}
 
-These APIs can be used to make apps faster by pre-loading resources such as scripts, stylesheets, and fonts as soon as you know you need them, for example before navigating to another page where the resources will be used.
+Essas APIs podem ser usadas para tornar os aplicativos mais rápidos, pré-carregando recursos como scripts, folhas de estilo e fontes assim que você souber que precisa deles, por exemplo, antes de navegar para outra página onde os recursos serão usados.
 
-[React-based frameworks](/learn/start-a-new-react-project) frequently handle resource loading for you, so you might not have to call these APIs yourself. Consult your framework's documentation for details.
+[Frameworks baseados em React](/learn/start-a-new-react-project) frequentemente cuidam do carregamento de recursos para você, então você pode não precisar chamar essas APIs diretamente. Consulte a documentação do seu framework para obter detalhes.
 
-* [`prefetchDNS`](/reference/react-dom/prefetchDNS) lets you prefetch the IP address of a DNS domain name that you expect to connect to.
-* [`preconnect`](/reference/react-dom/preconnect) lets you connect to a server you expect to request resources from, even if you don't know what resources you'll need yet.
-* [`preload`](/reference/react-dom/preload) lets you fetch a stylesheet, font, image, or external script that you expect to use.
-* [`preloadModule`](/reference/react-dom/preloadModule) lets you fetch an ESM module that you expect to use.
-* [`preinit`](/reference/react-dom/preinit) lets you fetch and evaluate an external script or fetch and insert a stylesheet.
-* [`preinitModule`](/reference/react-dom/preinitModule) lets you fetch and evaluate an ESM module.
+* [`prefetchDNS`](/reference/react-dom/prefetchDNS) permite pré-carregar o endereço IP de um nome de domínio DNS com o qual você espera se conectar.
+* [`preconnect`](/reference/react-dom/preconnect) permite que você se conecte a um servidor do qual espera solicitar recursos, mesmo que ainda não saiba quais recursos precisará.
+* [`preload`](/reference/react-dom/preload) permite que você busque uma folha de estilo, fonte, imagem ou script externo que você espera usar.
+* [`preloadModule`](/reference/react-dom/preloadModule) permite que você busque um módulo ESM que você espera usar.
+* [`preinit`](/reference/react-dom/preinit) permite que você busque e avalie um script externo ou busque e insira uma folha de estilo.
+* [`preinitModule`](/reference/react-dom/preinitModule) permite que você busque e avalie um módulo ESM.
 
 ---
 
-## Entry points {/*entry-points*/}
+## Pontos de Entrada {/*entry-points*/}
 
 O pacote `react-dom` fornece dois pontos de entrada adicionais:
 


### PR DESCRIPTION
This pull request contains an automated translation of the referenced page to **Brazilian Portuguese**.


> [!IMPORTANT]
> This translation was generated using AI/LLM and requires human review for accuracy, cultural context, and technical terminology.

<details>
<summary>Translation Details</summary>

### Processing Statistics

| Metric | Value |
|--------|-------|
| **Source File Size** | 3.2 KB |
| **Translation Size** | 3.3 KB |
| **Content Ratio** | 1.04x |
| **File Path** | `src/content/reference/react-dom/index.md` |
| **Processing Time** | ~5628s |

###### ps.: The content ratio indicates how the translation length compares to the source (1.0x = same length, >1.0x = translation is longer). Different languages naturally have varying verbosity levels.

### Technical Information

- **Target Language**: Brazilian Portuguese (`pt-br`)
- **AI Model**: `google/gemini-2.5-flash-lite` via Open Router API
- **Generated**: 2025-12-18
- **Branch**: `refs/heads/translate/reference/react-dom/index.md`
- **Translation Tool Version**: `translate-react v0.1.17`


</details>

## Additional Resources

- [Source Repository](https://github.com/NivaldoFarias/translate-react): Workflow and tooling details
- [Translation Workflow Documentation](https://github.com/NivaldoFarias/translate-react#readme): Process overview and guidelines