### PR TITLE
Translate `index.md` to Brazilian Portuguese

### DIFF
--- a/src/content/reference/react/index.md
+++ b/src/content/reference/react/index.md
@@ -4,7 +4,7 @@ title: Visão geral da referência do React
 
 <Intro>
 
-Esta seção fornece documentação de referência detalhada para trabalhar com React. Para uma introdução ao React, visite a seção [Aprender](/learn).
+Esta seção fornece documentação de referência detalhada para trabalhar com o React. Para uma introdução ao React, visite a seção [Aprender](/learn).
 
 </Intro>
 
@@ -12,7 +12,7 @@ A documentação de referência do React é dividida em subseções funcionais:
 
 ## React {/*react*/}
 
-Recursos do React Programático:
+Recursos programáticos do React:
 
 * [Hooks](/reference/react/hooks) - Use diferentes recursos do React a partir dos seus componentes.
 * [Componentes](/reference/react/components) - Componentes integrados que você pode usar no seu JSX.
@@ -21,30 +21,30 @@ Recursos do React Programático:
 
 ## React DOM {/*react-dom*/}
 
-React-dom contém recursos que são suportados apenas por aplicativos da web (que são executados no ambiente DOM do navegador). Esta seção é dividida no seguinte:
+O React DOM contém recursos que são suportados apenas por aplicativos da web (que são executados no ambiente DOM do navegador). Esta seção é dividida no seguinte:
 
 * [Hooks](/reference/react-dom/hooks) - Hooks para aplicações web que rodam no ambiente DOM do navegador.
-* [Componentes](/reference/react-dom/components) - React suporta todos os componentes HTML e SVG integrados do navegador.
+* [Componentes](/reference/react-dom/components) - O React suporta todos os componentes HTML e SVG integrados do navegador.
 * [APIs](/reference/react-dom) - O pacote `react-dom` contém métodos suportados apenas em aplicações web.
 * [APIs do cliente](/reference/react-dom/client) - As APIs `react-dom/client` permitem renderizar componentes do React no cliente (no navegador).
 * [APIs de servidor](/reference/react-dom/server) - As APIs `react-dom/server` permitem renderizar componentes React para HTML no servidor.
 
 ## React Compiler {/*react-compiler*/}
 
-The React Compiler is a build-time optimization tool that automatically memoizes your React components and values:
+O React Compiler é uma ferramenta de otimização em tempo de compilação que memoriza automaticamente seus componentes e valores React:
 
-* [Configuration](/reference/react-compiler/configuration) - Configuration options for React Compiler.
-* [Directives](/reference/react-compiler/directives) - Function-level directives to control compilation.
-* [Compiling Libraries](/reference/react-compiler/compiling-libraries) - Guide for shipping pre-compiled library code.
+* [Configuração](/reference/react-compiler/configuration) - Opções de configuração para o React Compiler.
+* [Diretivas](/reference/react-compiler/directives) - Diretivas em nível de função para controlar a compilação.
+* [Compilando Bibliotecas](/reference/react-compiler/compiling-libraries) - Guia para distribuir código de biblioteca pré-compilado.
 
-## Rules of React {/*rules-of-react*/}
+## Regras do React {/*rules-of-react*/}
 
-React has idioms — or rules — for how to express patterns in a way that is easy to understand and yields high-quality applications:
+O React tem idiomatismos — ou regras — sobre como expressar padrões de uma forma que seja fácil de entender e resulte em aplicações de alta qualidade:
 
-* [Components and Hooks must be pure](/reference/rules/components-and-hooks-must-be-pure) – Purity makes your code easier to understand, debug, and allows React to automatically optimize your components and hooks correctly.
-* [React calls Components and Hooks](/reference/rules/react-calls-components-and-hooks) – React is responsible for rendering components and hooks when necessary to optimize the user experience.
-* [Rules of Hooks](/reference/rules/rules-of-hooks) – Hooks are defined using JavaScript functions, but they represent a special type of reusable UI logic with restrictions on where they can be called.
+* [Componentes e Hooks devem ser puros](/reference/rules/components-and-hooks-must-be-pure) – A pureza torna seu código mais fácil de entender, depurar e permite que o React otimize automaticamente seus componentes e hooks corretamente.
+* [React chama Componentes e Hooks](/reference/rules/react-calls-components-and-hooks) – O React é responsável por renderizar componentes e hooks quando necessário para otimizar a experiência do usuário.
+* [Regras dos Hooks](/reference/rules/rules-of-hooks) – Hooks são definidos usando funções JavaScript, mas representam um tipo especial de lógica de UI reutilizável com restrições sobre onde podem ser chamados.
 
-## Legacy APIs {/*legacy-apis*/}
+## APIs Legadas {/*legacy-apis*/}
 
-* [Legacy APIs](/reference/react/legacy) - Exportado do pacote `react`, mas não recomendado para uso em código recém-escrito.
+* [APIs Legadas](/reference/react/legacy) - Exportado do pacote `react`, mas não recomendado para uso em código recém-escrito.


### PR DESCRIPTION
This pull request contains an automated translation of the referenced page to **Brazilian Portuguese**.


> [!IMPORTANT]
> This translation was generated using AI/LLM and requires human review for accuracy, cultural context, and technical terminology.

<details>
<summary>Translation Details</summary>

### Processing Statistics

| Metric | Value |
|--------|-------|
| **Source File Size** | 2.9 KB |
| **Translation Size** | 3.0 KB |
| **Content Ratio** | 1.03x |
| **File Path** | `src/content/reference/react/index.md` |
| **Processing Time** | ~6469s |

###### ps.: The content ratio indicates how the translation length compares to the source (1.0x = same length, >1.0x = translation is longer). Different languages naturally have varying verbosity levels.

### Technical Information

- **Target Language**: Brazilian Portuguese (`pt-br`)
- **AI Model**: `google/gemini-2.5-flash-lite` via Open Router API
- **Generated**: 2025-12-18
- **Branch**: `refs/heads/translate/reference/react/index.md`
- **Translation Tool Version**: `translate-react v0.1.17`


</details>

## Additional Resources

- [Source Repository](https://github.com/NivaldoFarias/translate-react): Workflow and tooling details
- [Translation Workflow Documentation](https://github.com/NivaldoFarias/translate-react#readme): Process overview and guidelines